### PR TITLE
Custom modules for fluid solver

### DIFF
--- a/include/inheritance_macros.h
+++ b/include/inheritance_macros.h
@@ -1,0 +1,55 @@
+#ifndef INHERETANCE_MACROS
+#define INHERETANCE_MACROS
+
+#define MPIFluidSolverInheritanceMacro()                                       \
+public:                                                                        \
+  using FluidSolver<dim>::add_hard_coded_boundary_condition;                   \
+  using FluidSolver<dim>::set_initial_condition;                               \
+                                                                               \
+private:                                                                       \
+  using FluidSolver<dim>::setup_dofs;                                          \
+  using FluidSolver<dim>::make_constraints;                                    \
+  using FluidSolver<dim>::setup_cell_property;                                 \
+  using FluidSolver<dim>::apply_initial_condition;                             \
+  using FluidSolver<dim>::refine_mesh;                                         \
+  using FluidSolver<dim>::output_results;                                      \
+  using FluidSolver<dim>::save_checkpoint;                                     \
+  using FluidSolver<dim>::load_checkpoint;                                     \
+  using FluidSolver<dim>::update_stress;                                       \
+                                                                               \
+  using FluidSolver<dim>::dofs_per_block;                                      \
+  using FluidSolver<dim>::triangulation;                                       \
+  using FluidSolver<dim>::fe;                                                  \
+  using FluidSolver<dim>::scalar_fe;                                           \
+  using FluidSolver<dim>::dof_handler;                                         \
+  using FluidSolver<dim>::scalar_dof_handler;                                  \
+  using FluidSolver<dim>::volume_quad_formula;                                 \
+  using FluidSolver<dim>::face_quad_formula;                                   \
+  using FluidSolver<dim>::zero_constraints;                                    \
+  using FluidSolver<dim>::nonzero_constraints;                                 \
+  using FluidSolver<dim>::sparsity_pattern;                                    \
+  using FluidSolver<dim>::system_matrix;                                       \
+  using FluidSolver<dim>::mass_matrix;                                         \
+  using FluidSolver<dim>::mass_schur;                                          \
+  using FluidSolver<dim>::present_solution;                                    \
+  using FluidSolver<dim>::solution_increment;                                  \
+  using FluidSolver<dim>::system_rhs;                                          \
+  using FluidSolver<dim>::fsi_acceleration;                                    \
+  using FluidSolver<dim>::stress;                                              \
+  using FluidSolver<dim>::parameters;                                          \
+  using FluidSolver<dim>::mpi_communicator;                                    \
+  using FluidSolver<dim>::pcout;                                               \
+  using FluidSolver<dim>::owned_partitioning;                                  \
+  using FluidSolver<dim>::relevant_partitioning;                               \
+  using FluidSolver<dim>::locally_owned_scalar_dofs;                           \
+  using FluidSolver<dim>::locally_relevant_dofs;                               \
+  using FluidSolver<dim>::locally_relevant_scalar_dofs;                        \
+  using FluidSolver<dim>::times_and_names;                                     \
+  using FluidSolver<dim>::time;                                                \
+  using FluidSolver<dim>::timer;                                               \
+  using FluidSolver<dim>::timer2;                                              \
+  using FluidSolver<dim>::cell_property;                                       \
+  using FluidSolver<dim>::hard_coded_boundary_values;                          \
+  using FluidSolver<dim>::initial_condition_field
+
+#endif

--- a/include/inheritance_macros.h
+++ b/include/inheritance_macros.h
@@ -52,4 +52,40 @@ private:                                                                       \
   using FluidSolver<dim>::hard_coded_boundary_values;                          \
   using FluidSolver<dim>::initial_condition_field
 
+#define MPISharedSolidSolverInheritanceMacro()                                 \
+private:                                                                       \
+  using SharedSolidSolver<dim>::triangulation;                                 \
+  using SharedSolidSolver<dim>::parameters;                                    \
+  using SharedSolidSolver<dim>::dof_handler;                                   \
+  using SharedSolidSolver<dim>::scalar_dof_handler;                            \
+  using SharedSolidSolver<dim>::fe;                                            \
+  using SharedSolidSolver<dim>::scalar_fe;                                     \
+  using SharedSolidSolver<dim>::volume_quad_formula;                           \
+  using SharedSolidSolver<dim>::face_quad_formula;                             \
+  using SharedSolidSolver<dim>::constraints;                                   \
+  using SharedSolidSolver<dim>::system_matrix;                                 \
+  using SharedSolidSolver<dim>::mass_matrix;                                   \
+  using SharedSolidSolver<dim>::stiffness_matrix;                              \
+  using SharedSolidSolver<dim>::damping_matrix;                                \
+  using SharedSolidSolver<dim>::system_rhs;                                    \
+  using SharedSolidSolver<dim>::current_acceleration;                          \
+  using SharedSolidSolver<dim>::current_velocity;                              \
+  using SharedSolidSolver<dim>::current_displacement;                          \
+  using SharedSolidSolver<dim>::previous_acceleration;                         \
+  using SharedSolidSolver<dim>::previous_velocity;                             \
+  using SharedSolidSolver<dim>::previous_displacement;                         \
+  using SharedSolidSolver<dim>::fsi_stress_rows;                               \
+  using SharedSolidSolver<dim>::strain;                                        \
+  using SharedSolidSolver<dim>::stress;                                        \
+  using SharedSolidSolver<dim>::mpi_communicator;                              \
+  using SharedSolidSolver<dim>::n_mpi_processes;                               \
+  using SharedSolidSolver<dim>::this_mpi_process;                              \
+  using SharedSolidSolver<dim>::pcout;                                         \
+  using SharedSolidSolver<dim>::time;                                          \
+  using SharedSolidSolver<dim>::timer;                                         \
+  using SharedSolidSolver<dim>::locally_owned_dofs;                            \
+  using SharedSolidSolver<dim>::locally_owned_scalar_dofs;                     \
+  using SharedSolidSolver<dim>::locally_relevant_dofs;                         \
+  using SharedSolidSolver<dim>::times_and_names
+
 #endif

--- a/include/inheritance_macros.h
+++ b/include/inheritance_macros.h
@@ -4,6 +4,8 @@
 #define MPIFluidSolverInheritanceMacro()                                       \
 public:                                                                        \
   using FluidSolver<dim>::add_hard_coded_boundary_condition;                   \
+  using FluidSolver<dim>::set_body_force;                                      \
+  using FluidSolver<dim>::set_sigma_pml_field;                                 \
   using FluidSolver<dim>::set_initial_condition;                               \
                                                                                \
 private:                                                                       \
@@ -50,6 +52,8 @@ private:                                                                       \
   using FluidSolver<dim>::timer2;                                              \
   using FluidSolver<dim>::cell_property;                                       \
   using FluidSolver<dim>::hard_coded_boundary_values;                          \
+  using FluidSolver<dim>::body_force;                                          \
+  using FluidSolver<dim>::sigma_pml_field;                                     \
   using FluidSolver<dim>::initial_condition_field
 
 #define MPISharedSolidSolverInheritanceMacro()                                 \

--- a/include/mpi_fluid_solver.h
+++ b/include/mpi_fluid_solver.h
@@ -60,6 +60,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "inheritance_macros.h"
 #include "parameters.h"
 #include "utilities.h"
 
@@ -95,15 +96,24 @@ namespace Fluid
       //! Destructor
       ~FluidSolver();
 
-      //! Setup the hard-coded boundary conditions. The first argument stands
-      //! for the boundary ID that the condition is applied to, and the second
-      //! is the hard-coded boundary value function. The ID must be included in
-      //! Dirichlet bunndaries in the parameters input file and calling this
-      //! function will override the original boundary condition.
+      /*! \brief Setup the hard-coded boundary conditions. The first argument
+       * stands for the boundary ID that the condition is applied to, and the
+       * second is the hard-coded boundary value function. The ID must be
+       * included in Dirichlet bunndaries in the parameters input file and
+       * calling this function will override the original boundary condition.
+       */
       void add_hard_coded_boundary_condition(
         const int,
         const std::function<
           double(const Point<dim> &, const unsigned int, const double)> &);
+
+      /*! \brief Setup the initial condition. A std::function can be passed into
+       * to solver where takes a dealii::Point<dim>, a component (0 to dim-1 for
+       * velocity and dim for pressure), and returns the initial condition
+       * value.
+       */
+      void set_initial_condition(
+        const std::function<double(const Point<dim> &, const unsigned int)> &);
 
       //! Return the solution for testing.
       PETScWrappers::MPI::BlockVector get_current_solution() const;
@@ -129,6 +139,9 @@ namespace Fluid
       /// Specify the sparsity pattern and reinit matrices and vectors based on
       /// the dofs and constraints.
       virtual void initialize_system();
+
+      /// Apply the initial condition passed to the solver.
+      void apply_initial_condition();
 
       /// Mesh adaption.
       void refine_mesh(const unsigned int, const unsigned int);
@@ -216,6 +229,11 @@ namespace Fluid
       /// Hard-coded boundary values, only used when told so in the input
       /// parameters.
       std::map<int, BoundaryValues> hard_coded_boundary_values;
+
+      /// Initial condition
+      std::shared_ptr<
+        std::function<double(const Point<dim> &, const unsigned int)>>
+        initial_condition_field;
 
       /// A data structure that caches the real/artificial fluid indicator,
       /// FSI stress, and FSI acceleration terms at quadrature points, that

--- a/include/mpi_fsi.h
+++ b/include/mpi_fsi.h
@@ -41,7 +41,7 @@ namespace MPI
     void run();
 
     void
-    set_penetration_criterion(const std::function<double(const Point<dim>)> &,
+    set_penetration_criterion(const std::function<double(const Point<dim> &)> &,
                               Tensor<1, dim>);
 
     //! Destructor
@@ -145,7 +145,7 @@ namespace MPI
       cell_hints;
 
     // A function that determines if a point is penetrating the fluid domain
-    std::shared_ptr<std::function<double(const Point<dim>)>>
+    std::shared_ptr<std::function<double(const Point<dim> &)>>
       penetration_criterion;
     Tensor<1, dim> penetration_direction;
 

--- a/include/mpi_insim.h
+++ b/include/mpi_insim.h
@@ -35,6 +35,8 @@ namespace Fluid
     template <int dim>
     class InsIM : public FluidSolver<dim>
     {
+      MPIFluidSolverInheritanceMacro();
+
     public:
       //! Constructor.
       InsIM(parallel::distributed::Triangulation<dim> &,
@@ -43,54 +45,8 @@ namespace Fluid
       //! Run the simulation.
       void run();
 
-      using FluidSolver<dim>::add_hard_coded_boundary_condition;
-
     private:
       class BlockSchurPreconditioner;
-
-      using FluidSolver<dim>::setup_dofs;
-      using FluidSolver<dim>::make_constraints;
-      using FluidSolver<dim>::setup_cell_property;
-      using FluidSolver<dim>::initialize_system;
-      using FluidSolver<dim>::refine_mesh;
-      using FluidSolver<dim>::output_results;
-      using FluidSolver<dim>::update_stress;
-      using FluidSolver<dim>::save_checkpoint;
-      using FluidSolver<dim>::load_checkpoint;
-
-      using FluidSolver<dim>::dofs_per_block;
-      using FluidSolver<dim>::triangulation;
-      using FluidSolver<dim>::fe;
-      using FluidSolver<dim>::scalar_fe;
-      using FluidSolver<dim>::dof_handler;
-      using FluidSolver<dim>::scalar_dof_handler;
-      using FluidSolver<dim>::volume_quad_formula;
-      using FluidSolver<dim>::face_quad_formula;
-      using FluidSolver<dim>::zero_constraints;
-      using FluidSolver<dim>::nonzero_constraints;
-      using FluidSolver<dim>::sparsity_pattern;
-      using FluidSolver<dim>::system_matrix;
-      using FluidSolver<dim>::mass_matrix;
-      using FluidSolver<dim>::mass_schur;
-      using FluidSolver<dim>::present_solution;
-      using FluidSolver<dim>::solution_increment;
-      using FluidSolver<dim>::system_rhs;
-      using FluidSolver<dim>::fsi_acceleration;
-      using FluidSolver<dim>::stress;
-      using FluidSolver<dim>::parameters;
-      using FluidSolver<dim>::mpi_communicator;
-      using FluidSolver<dim>::pcout;
-      using FluidSolver<dim>::owned_partitioning;
-      using FluidSolver<dim>::relevant_partitioning;
-      using FluidSolver<dim>::locally_owned_scalar_dofs;
-      using FluidSolver<dim>::locally_relevant_dofs;
-      using FluidSolver<dim>::locally_relevant_scalar_dofs;
-      using FluidSolver<dim>::times_and_names;
-      using FluidSolver<dim>::time;
-      using FluidSolver<dim>::timer;
-      using FluidSolver<dim>::timer2;
-      using FluidSolver<dim>::cell_property;
-      using FluidSolver<dim>::hard_coded_boundary_values;
 
       /// Specify the sparsity pattern and reinit matrices and vectors based on
       /// the dofs and constraints.

--- a/include/mpi_insimex.h
+++ b/include/mpi_insimex.h
@@ -31,6 +31,8 @@ namespace Fluid
     template <int dim>
     class InsIMEX : public FluidSolver<dim>
     {
+      MPIFluidSolverInheritanceMacro();
+
     public:
       //! Constructor.
       InsIMEX(parallel::distributed::Triangulation<dim> &,
@@ -39,52 +41,8 @@ namespace Fluid
       //! Run the simulation.
       void run();
 
-      using FluidSolver<dim>::add_hard_coded_boundary_condition;
-
     private:
       class BlockSchurPreconditioner;
-
-      using FluidSolver<dim>::setup_dofs;
-      using FluidSolver<dim>::make_constraints;
-      using FluidSolver<dim>::setup_cell_property;
-      using FluidSolver<dim>::initialize_system;
-      using FluidSolver<dim>::refine_mesh;
-      using FluidSolver<dim>::output_results;
-      using FluidSolver<dim>::update_stress;
-      using FluidSolver<dim>::save_checkpoint;
-      using FluidSolver<dim>::load_checkpoint;
-
-      using FluidSolver<dim>::dofs_per_block;
-      using FluidSolver<dim>::triangulation;
-      using FluidSolver<dim>::fe;
-      using FluidSolver<dim>::scalar_fe;
-      using FluidSolver<dim>::dof_handler;
-      using FluidSolver<dim>::scalar_dof_handler;
-      using FluidSolver<dim>::volume_quad_formula;
-      using FluidSolver<dim>::face_quad_formula;
-      using FluidSolver<dim>::zero_constraints;
-      using FluidSolver<dim>::nonzero_constraints;
-      using FluidSolver<dim>::sparsity_pattern;
-      using FluidSolver<dim>::system_matrix;
-      using FluidSolver<dim>::mass_matrix;
-      using FluidSolver<dim>::mass_schur;
-      using FluidSolver<dim>::present_solution;
-      using FluidSolver<dim>::system_rhs;
-      using FluidSolver<dim>::fsi_acceleration;
-      using FluidSolver<dim>::parameters;
-      using FluidSolver<dim>::mpi_communicator;
-      using FluidSolver<dim>::pcout;
-      using FluidSolver<dim>::owned_partitioning;
-      using FluidSolver<dim>::relevant_partitioning;
-      using FluidSolver<dim>::locally_owned_scalar_dofs;
-      using FluidSolver<dim>::locally_relevant_dofs;
-      using FluidSolver<dim>::locally_relevant_scalar_dofs;
-      using FluidSolver<dim>::times_and_names;
-      using FluidSolver<dim>::time;
-      using FluidSolver<dim>::timer;
-      using FluidSolver<dim>::timer2;
-      using FluidSolver<dim>::cell_property;
-      using FluidSolver<dim>::hard_coded_boundary_values;
 
       /// Specify the sparsity pattern and reinit matrices and vectors based on
       /// the dofs and constraints.
@@ -114,7 +72,7 @@ namespace Fluid
                         bool assemble_system = true) override;
 
       /// The increment at a certain time step.
-      PETScWrappers::MPI::BlockVector solution_increment;
+      PETScWrappers::MPI::BlockVector solution_time_increment;
 
       /// The BlockSchurPreconditioner for the entire system.
       std::shared_ptr<BlockSchurPreconditioner> preconditioner;

--- a/include/mpi_scnsex.h
+++ b/include/mpi_scnsex.h
@@ -37,13 +37,7 @@ namespace Fluid
     public:
       //! Constructor.
       SCnsEX(parallel::distributed::Triangulation<dim> &,
-             const Parameters::AllParameters &,
-             std::shared_ptr<Function<dim>> pml =
-               std::make_shared<Functions::ZeroFunction<dim>>(
-                 Functions::ZeroFunction<dim>(dim + 1)),
-             std::shared_ptr<TensorFunction<1, dim>> bf =
-               std::make_shared<ZeroTensorFunction<1, dim>>(
-                 ZeroTensorFunction<1, dim>()));
+             const Parameters::AllParameters &);
       ~SCnsEX(){};
       //! Run the simulation.
       void run();
@@ -88,14 +82,6 @@ namespace Fluid
       void run_one_step(bool apply_nonzero_constraints,
                         bool assemble_system) override;
 
-      /*! \brief Apply the initial condition
-       *
-       * This is a hard-coded function that is only used for VF cases where an
-       * initial condition is applied for fast convergence. For general cases,
-       * do not include it.
-       */
-      void apply_initial_condition();
-
       /*! The intermiediate solution within every time step, generated from each
        * iteration.
        */
@@ -107,17 +93,6 @@ namespace Fluid
        * to the quadrature points when do the assembly.
        */
       PETScWrappers::MPI::BlockVector evaluation_point;
-
-      /** \brief sigma_pml_field
-       * the sigma_pml_field is predefined outside the class. It specifies
-       * the sigma PML field to determine where and how sigma pml is
-       * distributed. With strong sigma PML it absorbs faster waves/vortices
-       * but reflects more slow waves/vortices.
-       */
-      std::shared_ptr<Function<dim>> sigma_pml_field;
-
-      /// Hard-coded body force. It will be added onto gravity.
-      std::shared_ptr<TensorFunction<1, dim>> body_force;
 
       /** \breif local_matrices
        * The local matrices is stored in each cell such that the program does

--- a/include/mpi_scnsex.h
+++ b/include/mpi_scnsex.h
@@ -32,6 +32,8 @@ namespace Fluid
     template <int dim>
     class SCnsEX : public FluidSolver<dim>
     {
+      MPIFluidSolverInheritanceMacro();
+
     public:
       //! Constructor.
       SCnsEX(parallel::distributed::Triangulation<dim> &,
@@ -53,50 +55,7 @@ namespace Fluid
       void set_hard_coded_boundary_condition_time(const unsigned int,
                                                   const double);
 
-      using FluidSolver<dim>::add_hard_coded_boundary_condition;
-
     private:
-      using FluidSolver<dim>::setup_dofs;
-      using FluidSolver<dim>::make_constraints;
-      using FluidSolver<dim>::setup_cell_property;
-      using FluidSolver<dim>::refine_mesh;
-      using FluidSolver<dim>::output_results;
-      using FluidSolver<dim>::save_checkpoint;
-      using FluidSolver<dim>::load_checkpoint;
-      using FluidSolver<dim>::update_stress;
-
-      using FluidSolver<dim>::dofs_per_block;
-      using FluidSolver<dim>::triangulation;
-      using FluidSolver<dim>::fe;
-      using FluidSolver<dim>::scalar_fe;
-      using FluidSolver<dim>::dof_handler;
-      using FluidSolver<dim>::scalar_dof_handler;
-      using FluidSolver<dim>::volume_quad_formula;
-      using FluidSolver<dim>::face_quad_formula;
-      using FluidSolver<dim>::zero_constraints;
-      using FluidSolver<dim>::nonzero_constraints;
-      using FluidSolver<dim>::sparsity_pattern;
-      using FluidSolver<dim>::system_matrix;
-      using FluidSolver<dim>::present_solution;
-      using FluidSolver<dim>::solution_increment;
-      using FluidSolver<dim>::system_rhs;
-      using FluidSolver<dim>::fsi_acceleration;
-      using FluidSolver<dim>::stress;
-      using FluidSolver<dim>::parameters;
-      using FluidSolver<dim>::mpi_communicator;
-      using FluidSolver<dim>::pcout;
-      using FluidSolver<dim>::owned_partitioning;
-      using FluidSolver<dim>::relevant_partitioning;
-      using FluidSolver<dim>::locally_owned_scalar_dofs;
-      using FluidSolver<dim>::locally_relevant_dofs;
-      using FluidSolver<dim>::locally_relevant_scalar_dofs;
-      using FluidSolver<dim>::times_and_names;
-      using FluidSolver<dim>::time;
-      using FluidSolver<dim>::timer;
-      using FluidSolver<dim>::timer2;
-      using FluidSolver<dim>::cell_property;
-      using FluidSolver<dim>::hard_coded_boundary_values;
-
       /// Specify the sparsity pattern and reinit matrices and vectors based on
       /// the dofs and constraints.
       virtual void initialize_system() override;

--- a/include/mpi_scnsim.h
+++ b/include/mpi_scnsim.h
@@ -39,13 +39,7 @@ namespace Fluid
     public:
       //! Constructor.
       SCnsIM(parallel::distributed::Triangulation<dim> &,
-             const Parameters::AllParameters &,
-             std::shared_ptr<Function<dim>> pml =
-               std::make_shared<Functions::ZeroFunction<dim>>(
-                 Functions::ZeroFunction<dim>(dim + 1)),
-             std::shared_ptr<TensorFunction<1, dim>> bf =
-               std::make_shared<ZeroTensorFunction<1, dim>>(
-                 ZeroTensorFunction<1, dim>()));
+             const Parameters::AllParameters &);
       ~SCnsIM(){};
       //! Run the simulation.
       void run();
@@ -105,17 +99,6 @@ namespace Fluid
 
       /// The BlockIncompSchurPreconditioner for the entire system.
       std::shared_ptr<BlockIncompSchurPreconditioner> preconditioner;
-
-      /** \brief sigma_pml_field
-       * the sigma_pml_field is predefined outside the class. It specifies
-       * the sigma PML field to determine where and how sigma pml is
-       * distributed. With strong sigma PML it absorbs faster waves/vortices
-       * but reflects more slow waves/vortices.
-       */
-      std::shared_ptr<Function<dim>> sigma_pml_field;
-
-      /// Hard-coded body force. It will be added onto gravity.
-      std::shared_ptr<TensorFunction<1, dim>> body_force;
 
       /** \brief Incomplete Schur Complement Block Preconditioner
        * The format of this preconditioner is as follow:

--- a/include/mpi_scnsim.h
+++ b/include/mpi_scnsim.h
@@ -34,6 +34,8 @@ namespace Fluid
     template <int dim>
     class SCnsIM : public FluidSolver<dim>
     {
+      MPIFluidSolverInheritanceMacro();
+
     public:
       //! Constructor.
       SCnsIM(parallel::distributed::Triangulation<dim> &,
@@ -48,51 +50,8 @@ namespace Fluid
       //! Run the simulation.
       void run();
 
-      using FluidSolver<dim>::add_hard_coded_boundary_condition;
-
     private:
       class BlockIncompSchurPreconditioner;
-
-      using FluidSolver<dim>::setup_dofs;
-      using FluidSolver<dim>::make_constraints;
-      using FluidSolver<dim>::setup_cell_property;
-      using FluidSolver<dim>::refine_mesh;
-      using FluidSolver<dim>::output_results;
-      using FluidSolver<dim>::save_checkpoint;
-      using FluidSolver<dim>::load_checkpoint;
-      using FluidSolver<dim>::update_stress;
-
-      using FluidSolver<dim>::dofs_per_block;
-      using FluidSolver<dim>::triangulation;
-      using FluidSolver<dim>::fe;
-      using FluidSolver<dim>::scalar_fe;
-      using FluidSolver<dim>::dof_handler;
-      using FluidSolver<dim>::scalar_dof_handler;
-      using FluidSolver<dim>::volume_quad_formula;
-      using FluidSolver<dim>::face_quad_formula;
-      using FluidSolver<dim>::zero_constraints;
-      using FluidSolver<dim>::nonzero_constraints;
-      using FluidSolver<dim>::sparsity_pattern;
-      using FluidSolver<dim>::system_matrix;
-      using FluidSolver<dim>::present_solution;
-      using FluidSolver<dim>::solution_increment;
-      using FluidSolver<dim>::system_rhs;
-      using FluidSolver<dim>::fsi_acceleration;
-      using FluidSolver<dim>::stress;
-      using FluidSolver<dim>::parameters;
-      using FluidSolver<dim>::mpi_communicator;
-      using FluidSolver<dim>::pcout;
-      using FluidSolver<dim>::owned_partitioning;
-      using FluidSolver<dim>::relevant_partitioning;
-      using FluidSolver<dim>::locally_owned_scalar_dofs;
-      using FluidSolver<dim>::locally_relevant_dofs;
-      using FluidSolver<dim>::locally_relevant_scalar_dofs;
-      using FluidSolver<dim>::times_and_names;
-      using FluidSolver<dim>::time;
-      using FluidSolver<dim>::timer;
-      using FluidSolver<dim>::timer2;
-      using FluidSolver<dim>::cell_property;
-      using FluidSolver<dim>::hard_coded_boundary_values;
 
       /// Specify the sparsity pattern and reinit matrices and vectors based on
       /// the dofs and constraints.
@@ -131,14 +90,6 @@ namespace Fluid
        */
       void run_one_step(bool apply_nonzero_constraints,
                         bool assemble_system = true) override;
-
-      /*! \brief Apply the initial condition
-       *
-       * This is a hard-coded function that is only used for VF cases where an
-       * initial condition is applied for fast convergence. For general cases,
-       * do not include it.
-       */
-      void apply_initial_condition();
 
       PETScWrappers::MPI::SparseMatrix Abs_A_matrix;
       PETScWrappers::MPI::SparseMatrix schur_matrix;

--- a/include/mpi_shared_hyper_elasticity.h
+++ b/include/mpi_shared_hyper_elasticity.h
@@ -91,44 +91,14 @@ namespace Solid
     template <int dim>
     class SharedHyperElasticity : public SharedSolidSolver<dim>
     {
+      MPISharedSolidSolverInheritanceMacro();
+
     public:
       SharedHyperElasticity(Triangulation<dim> &,
                             const Parameters::AllParameters &);
       ~SharedHyperElasticity() {}
 
     private:
-      using SharedSolidSolver<dim>::triangulation;
-      using SharedSolidSolver<dim>::parameters;
-      using SharedSolidSolver<dim>::dof_handler;
-      using SharedSolidSolver<dim>::scalar_dof_handler;
-      using SharedSolidSolver<dim>::fe;
-      using SharedSolidSolver<dim>::scalar_fe;
-      using SharedSolidSolver<dim>::volume_quad_formula;
-      using SharedSolidSolver<dim>::face_quad_formula;
-      using SharedSolidSolver<dim>::constraints;
-      using SharedSolidSolver<dim>::system_matrix;
-      using SharedSolidSolver<dim>::mass_matrix;
-      using SharedSolidSolver<dim>::system_rhs;
-      using SharedSolidSolver<dim>::current_acceleration;
-      using SharedSolidSolver<dim>::current_velocity;
-      using SharedSolidSolver<dim>::current_displacement;
-      using SharedSolidSolver<dim>::previous_acceleration;
-      using SharedSolidSolver<dim>::previous_velocity;
-      using SharedSolidSolver<dim>::previous_displacement;
-      using SharedSolidSolver<dim>::fsi_stress_rows;
-      using SharedSolidSolver<dim>::strain;
-      using SharedSolidSolver<dim>::stress;
-      using SharedSolidSolver<dim>::mpi_communicator;
-      using SharedSolidSolver<dim>::n_mpi_processes;
-      using SharedSolidSolver<dim>::this_mpi_process;
-      using SharedSolidSolver<dim>::pcout;
-      using SharedSolidSolver<dim>::time;
-      using SharedSolidSolver<dim>::timer;
-      using SharedSolidSolver<dim>::locally_owned_dofs;
-      using SharedSolidSolver<dim>::locally_owned_scalar_dofs;
-      using SharedSolidSolver<dim>::locally_relevant_dofs;
-      using SharedSolidSolver<dim>::times_and_names;
-
       void initialize_system() override;
 
       virtual void update_strain_and_stress() override;

--- a/include/mpi_shared_hypo_elasticity.h
+++ b/include/mpi_shared_hypo_elasticity.h
@@ -28,6 +28,8 @@ namespace Solid
     template <int dim>
     class SharedHypoElasticity : public SharedSolidSolver<dim>
     {
+      MPISharedSolidSolverInheritanceMacro();
+
     public:
       SharedHypoElasticity(Triangulation<dim> &,
                            const Parameters::AllParameters &,
@@ -36,38 +38,6 @@ namespace Solid
       ~SharedHypoElasticity() {}
 
     private:
-      using SharedSolidSolver<dim>::triangulation;
-      using SharedSolidSolver<dim>::parameters;
-      using SharedSolidSolver<dim>::dof_handler;
-      using SharedSolidSolver<dim>::scalar_dof_handler;
-      using SharedSolidSolver<dim>::fe;
-      using SharedSolidSolver<dim>::scalar_fe;
-      using SharedSolidSolver<dim>::volume_quad_formula;
-      using SharedSolidSolver<dim>::face_quad_formula;
-      using SharedSolidSolver<dim>::constraints;
-      using SharedSolidSolver<dim>::system_matrix;
-      using SharedSolidSolver<dim>::mass_matrix;
-      using SharedSolidSolver<dim>::system_rhs;
-      using SharedSolidSolver<dim>::current_acceleration;
-      using SharedSolidSolver<dim>::current_velocity;
-      using SharedSolidSolver<dim>::current_displacement;
-      using SharedSolidSolver<dim>::previous_acceleration;
-      using SharedSolidSolver<dim>::previous_velocity;
-      using SharedSolidSolver<dim>::previous_displacement;
-      using SharedSolidSolver<dim>::fsi_stress_rows;
-      using SharedSolidSolver<dim>::strain;
-      using SharedSolidSolver<dim>::stress;
-      using SharedSolidSolver<dim>::mpi_communicator;
-      using SharedSolidSolver<dim>::n_mpi_processes;
-      using SharedSolidSolver<dim>::this_mpi_process;
-      using SharedSolidSolver<dim>::pcout;
-      using SharedSolidSolver<dim>::time;
-      using SharedSolidSolver<dim>::timer;
-      using SharedSolidSolver<dim>::locally_owned_dofs;
-      using SharedSolidSolver<dim>::locally_owned_scalar_dofs;
-      using SharedSolidSolver<dim>::locally_relevant_dofs;
-      using SharedSolidSolver<dim>::times_and_names;
-
       void initialize_system() override;
 
       virtual void update_strain_and_stress() override;

--- a/include/mpi_shared_linear_elasticity.h
+++ b/include/mpi_shared_linear_elasticity.h
@@ -36,6 +36,8 @@ namespace Solid
     template <int dim>
     class SharedLinearElasticity : public SharedSolidSolver<dim>
     {
+      MPISharedSolidSolverInheritanceMacro();
+
     public:
       /*! \brief Constructor.
        *
@@ -49,39 +51,6 @@ namespace Solid
       ~SharedLinearElasticity() {}
 
     private:
-      using SharedSolidSolver<dim>::triangulation;
-      using SharedSolidSolver<dim>::parameters;
-      using SharedSolidSolver<dim>::dof_handler;
-      using SharedSolidSolver<dim>::scalar_dof_handler;
-      using SharedSolidSolver<dim>::fe;
-      using SharedSolidSolver<dim>::scalar_fe;
-      using SharedSolidSolver<dim>::volume_quad_formula;
-      using SharedSolidSolver<dim>::face_quad_formula;
-      using SharedSolidSolver<dim>::constraints;
-      using SharedSolidSolver<dim>::system_matrix;
-      using SharedSolidSolver<dim>::stiffness_matrix;
-      using SharedSolidSolver<dim>::damping_matrix;
-      using SharedSolidSolver<dim>::system_rhs;
-      using SharedSolidSolver<dim>::current_acceleration;
-      using SharedSolidSolver<dim>::current_velocity;
-      using SharedSolidSolver<dim>::current_displacement;
-      using SharedSolidSolver<dim>::previous_acceleration;
-      using SharedSolidSolver<dim>::previous_velocity;
-      using SharedSolidSolver<dim>::previous_displacement;
-      using SharedSolidSolver<dim>::fsi_stress_rows;
-      using SharedSolidSolver<dim>::strain;
-      using SharedSolidSolver<dim>::stress;
-      using SharedSolidSolver<dim>::mpi_communicator;
-      using SharedSolidSolver<dim>::n_mpi_processes;
-      using SharedSolidSolver<dim>::this_mpi_process;
-      using SharedSolidSolver<dim>::pcout;
-      using SharedSolidSolver<dim>::time;
-      using SharedSolidSolver<dim>::timer;
-      using SharedSolidSolver<dim>::locally_owned_dofs;
-      using SharedSolidSolver<dim>::locally_owned_scalar_dofs;
-      using SharedSolidSolver<dim>::locally_relevant_dofs;
-      using SharedSolidSolver<dim>::times_and_names;
-
       /**
        * Assembles lhs and rhs. At time step 0, the lhs is the mass matrix;
        * at all the following steps, it is \f$ M + \beta{\Delta{t}}^2K \f$.

--- a/include/mpi_shared_solid_solver.h
+++ b/include/mpi_shared_solid_solver.h
@@ -59,6 +59,7 @@
 #include <fstream>
 #include <iostream>
 
+#include "inheritance_macros.h"
 #include "parameters.h"
 #include "utilities.h"
 

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -30,6 +30,7 @@ set(headers fluid_solver.h
             fsi.h
             hyper_elastic_material.h
             hyper_elasticity.h
+            inheritance_macros.h
             insim.h
             insimex.h
             linear_elastic_material.h

--- a/source/mpi_insimex.cpp
+++ b/source/mpi_insimex.cpp
@@ -143,7 +143,7 @@ namespace Fluid
       preconditioner.reset();
       // newton_update is non-ghosted because the linear solver needs
       // a completely distributed vector.
-      solution_increment.reinit(owned_partitioning, mpi_communicator);
+      solution_time_increment.reinit(owned_partitioning, mpi_communicator);
     }
 
     template <int dim>
@@ -383,11 +383,11 @@ namespace Fluid
 
       // The solution vector must be non-ghosted
       gmres.solve(
-        system_matrix, solution_increment, system_rhs, *preconditioner);
+        system_matrix, solution_time_increment, system_rhs, *preconditioner);
 
       const AffineConstraints<double> &constraints_used =
         use_nonzero_constraints ? nonzero_constraints : zero_constraints;
-      constraints_used.distribute(solution_increment);
+      constraints_used.distribute(solution_time_increment);
 
       return {solver_control.last_step(), solver_control.last_value()};
     }
@@ -410,7 +410,7 @@ namespace Fluid
             << ", at t = " << std::scientific << time.current() << std::endl;
 
       // Resetting
-      solution_increment = 0;
+      solution_time_increment = 0;
       assemble(apply_nonzero_constraints,
                assemble_system || (parameters.simulation_type == "Fluid" &&
                                    time.time_to_refine()));
@@ -420,7 +420,7 @@ namespace Fluid
       PETScWrappers::MPI::BlockVector tmp;
       tmp.reinit(owned_partitioning, mpi_communicator);
       tmp = present_solution;
-      tmp += solution_increment;
+      tmp += solution_time_increment;
       present_solution = tmp;
 
       pcout << std::scientific << std::left << " GMRES_ITR = " << std::setw(3)

--- a/source/mpi_scnsex.cpp
+++ b/source/mpi_scnsex.cpp
@@ -6,10 +6,8 @@ namespace Fluid
   {
     template <int dim>
     SCnsEX<dim>::SCnsEX(parallel::distributed::Triangulation<dim> &tria,
-                        const Parameters::AllParameters &parameters,
-                        std::shared_ptr<Function<dim>> pml,
-                        std::shared_ptr<TensorFunction<1, dim>> bf)
-      : FluidSolver<dim>(tria, parameters), sigma_pml_field(pml), body_force(bf)
+                        const Parameters::AllParameters &parameters)
+      : FluidSolver<dim>(tria, parameters)
     {
       AssertThrow(parameters.fluid_velocity_degree ==
                     parameters.fluid_pressure_degree,
@@ -51,6 +49,11 @@ namespace Fluid
 
       // Cell property
       setup_cell_property();
+
+      if (initial_condition_field)
+        {
+          apply_initial_condition();
+        }
 
       // Setup local matrices
       for (auto cell = triangulation.begin_active();
@@ -173,6 +176,15 @@ namespace Fluid
       const double cp_to_cv = 1.4;
       const double atm = 1013250;
 
+      // Zero out sigma field and body force if their fields are not specified
+      if (sigma_pml_field == nullptr)
+        {
+          for (auto &e : sigma_pml)
+            {
+              e = 0.0;
+            }
+        }
+
       for (auto cell = dof_handler.begin_active(); cell != dof_handler.end();
            ++cell)
         {
@@ -207,10 +219,16 @@ namespace Fluid
                     evaluation_point, current_pressure_values);
                 }
 
-              sigma_pml_field->value_list(
-                fe_values.get_quadrature_points(), sigma_pml, 0);
-              body_force->value_list(fe_values.get_quadrature_points(),
-                                     artificial_bf);
+              if (sigma_pml_field)
+                {
+                  sigma_pml_field->double_value_list(
+                    fe_values.get_quadrature_points(), sigma_pml, 0);
+                }
+              if (body_force)
+                {
+                  body_force->tensor_value_list(
+                    fe_values.get_quadrature_points(), artificial_bf);
+                }
 
               for (unsigned int q = 0; q < n_q_points; ++q)
                 {
@@ -499,60 +517,6 @@ namespace Fluid
           refine_mesh(parameters.global_refinements[0],
                       parameters.global_refinements[0] + 3);
         }
-    }
-
-    template <int dim>
-    void SCnsEX<dim>::apply_initial_condition()
-    {
-      const double pressure = 1e4;
-      AffineConstraints<double> initial_condition;
-      initial_condition.reinit(locally_relevant_dofs);
-
-      const std::vector<Point<dim>> &unit_points = fe.get_unit_support_points();
-      Quadrature<dim> dummy_q(unit_points.size());
-      MappingQGeneric<dim> mapping(1);
-      FEValues<dim> dummy_fe_values(
-        mapping, fe, dummy_q, update_quadrature_points);
-
-      std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
-      for (auto cell = dof_handler.begin_active(); cell != dof_handler.end();
-           ++cell)
-        {
-          if (cell->is_artificial())
-            continue;
-          dummy_fe_values.reinit(cell);
-          auto support_points = dummy_fe_values.get_quadrature_points();
-          cell->get_dof_indices(dof_indices);
-          for (unsigned int i = 0; i < unit_points.size(); ++i)
-            {
-              auto base_index = fe.system_to_base_index(i);
-              const unsigned int i_group = base_index.first.first;
-              Assert(
-                i_group < 2,
-                ExcMessage("There should be only 2 groups of finite element!"));
-              if (i_group == 0)
-                continue; // skip the velocity dofs
-              if (support_points[i][0] > 4.0 && support_points[i][0] < 5.0)
-                {
-                  auto line = dof_indices[i];
-                  initial_condition.add_line(line);
-                  initial_condition.set_inhomogeneity(
-                    line, pressure * (support_points[i][0] - 4.0));
-                }
-              else if (support_points[i][0] >= 5.0 &&
-                       support_points[i][0] < 12.0)
-                {
-                  auto line = dof_indices[i];
-                  initial_condition.add_line(line);
-                  initial_condition.set_inhomogeneity(line, pressure);
-                }
-            }
-        }
-      initial_condition.close();
-      PETScWrappers::MPI::BlockVector tmp;
-      tmp.reinit(owned_partitioning, mpi_communicator);
-      initial_condition.distribute(tmp);
-      present_solution = tmp;
     }
 
     template <int dim>

--- a/source/mpi_scnsim.cpp
+++ b/source/mpi_scnsim.cpp
@@ -276,8 +276,10 @@ namespace Fluid
           PETScWrappers::MPI::Vector(locally_owned_scalar_dofs,
                                      mpi_communicator)));
 
-      // Hard-coded initial condition, only for VF cases!
-      // apply_initial_condition();
+      if (initial_condition_field)
+        {
+          apply_initial_condition();
+        }
     }
 
     template <int dim>
@@ -844,60 +846,6 @@ namespace Fluid
           refine_mesh(parameters.global_refinements[0],
                       parameters.global_refinements[0] + 3);
         }
-    }
-
-    template <int dim>
-    void SCnsIM<dim>::apply_initial_condition()
-    {
-      const double pressure = 1e4;
-      AffineConstraints<double> initial_condition;
-      initial_condition.reinit(locally_relevant_dofs);
-
-      const std::vector<Point<dim>> &unit_points = fe.get_unit_support_points();
-      Quadrature<dim> dummy_q(unit_points.size());
-      MappingQGeneric<dim> mapping(1);
-      FEValues<dim> dummy_fe_values(
-        mapping, fe, dummy_q, update_quadrature_points);
-
-      std::vector<types::global_dof_index> dof_indices(fe.dofs_per_cell);
-      for (auto cell = dof_handler.begin_active(); cell != dof_handler.end();
-           ++cell)
-        {
-          if (cell->is_artificial())
-            continue;
-          dummy_fe_values.reinit(cell);
-          auto support_points = dummy_fe_values.get_quadrature_points();
-          cell->get_dof_indices(dof_indices);
-          for (unsigned int i = 0; i < unit_points.size(); ++i)
-            {
-              auto base_index = fe.system_to_base_index(i);
-              const unsigned int i_group = base_index.first.first;
-              Assert(
-                i_group < 2,
-                ExcMessage("There should be only 2 groups of finite element!"));
-              if (i_group == 0)
-                continue; // skip the velocity dofs
-              if (support_points[i][0] > 4.0 && support_points[i][0] < 5.0)
-                {
-                  auto line = dof_indices[i];
-                  initial_condition.add_line(line);
-                  initial_condition.set_inhomogeneity(
-                    line, pressure * (support_points[i][0] - 4.0));
-                }
-              else if (support_points[i][0] >= 5.0 &&
-                       support_points[i][0] < 12.0)
-                {
-                  auto line = dof_indices[i];
-                  initial_condition.add_line(line);
-                  initial_condition.set_inhomogeneity(line, pressure);
-                }
-            }
-        }
-      initial_condition.close();
-      PETScWrappers::MPI::BlockVector tmp;
-      tmp.reinit(owned_partitioning, mpi_communicator);
-      initial_condition.distribute(tmp);
-      present_solution = tmp;
     }
 
     template <int dim>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,9 +19,10 @@ set(serial_tests acoustic_duct_wave
 set(mpi_tests acoustic_duct_wave_mpi
               acoustic_duct_wave_mpi_scnsex
               acoustic_pml_mpi
-              fluid_initial_condition_mpi
+              fluid_body_force_mpi
               fluid_cylinder_mpi
               fluid_cylinder_mpi_insimex
+              fluid_initial_condition_mpi
               fluid_pipe_mpi
               fsi_contact_model_mpi
               fsi_gravity_mpi

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(serial_tests acoustic_duct_wave
 set(mpi_tests acoustic_duct_wave_mpi
               acoustic_duct_wave_mpi_scnsex
               acoustic_pml_mpi
+              fluid_initial_condition_mpi
               fluid_cylinder_mpi
               fluid_cylinder_mpi_insimex
               fluid_pipe_mpi

--- a/tests/fluid_body_force_mpi/fluid_body_force_mpi.prm
+++ b/tests/fluid_body_force_mpi/fluid_body_force_mpi.prm
@@ -1,0 +1,179 @@
+# This is the input file for the program. There are three blocks of input parameters,
+# namely the simulation block, which contorls the simulation parameters shared by
+# both fluid and solid, such as the simulation time, output frequency and so on.
+# The fluid block controls the behavior of the fluid solver, and the solid solver
+# controls the solid solver.
+#
+# --------------------------------------------------------------------------------
+# Simulation parameters
+subsection Simulation
+  # Type of simulation: FSI/Fluid/Solid
+  set Simulation type = Fluid
+
+  # The dimension of the simulation
+  set Dimension = 2
+
+  # Level of global refinement before running,
+  # which applies to all the solvers
+  set Global refinements = 0, 0
+
+  # The end time of the simulation in second
+  set End time = 5e-5
+
+  # The time step in second
+  set Time step size = 1e-7
+
+  # The output interval in second
+  set Output interval = 1e-6
+
+  # Mesh refinement interval in second
+  set Refinement interval = 10
+
+  # Checkpoint save interval in second
+  set Save interval = 1e-1
+
+  # Body force which applies to solid only (acceleration)
+  set Gravity = 0.0, 0.0
+end
+
+# --------------------------------------------------------------------------------
+# Fluid solver
+subsection Fluid finite element system
+  # The degree of pressure element
+  set Pressure degree = 1
+
+  # The degree of velocity element. For grad-div solver this must be one higher than pressure
+  set Velocity degree = 1
+end
+
+subsection Fluid material properties
+  # The dynamic viscosity
+  set Dynamic viscosity = 1.8e-4
+
+  # Fluid density
+  set Fluid density = 1.3e-3
+end
+
+subsection Fluid solver control
+  # The global Grad-Div stabilization, empirically should be in [0.1, 1]
+  set Grad-Div stabilization = 0.1
+
+  # Maximum number of Newton iterations at a time step
+  set Max Newton iterations = 8
+
+  # The relative tolerance of the nonlinear system residual
+  set Nonlinear system tolerance = 1e-6
+end
+
+subsection Fluid Dirichlet BCs
+  # Use the hard-coded boundary values or the input values.
+  # Note: even if this variable is set to 1, the following 3 variables
+  # will still be used so that the hard-coded values BCs applies to the
+  # target boundaries and directions only.
+  set Use hard-coded boundary values = 0
+
+  # Number of boundaries with Dirichlet BCs
+  set Number of Dirichlet BCs = 4
+
+  # List all the boundaries with Dirichlet BCs
+  set Dirichlet boundary id = 0, 1, 2, 3
+
+  # List the constrained components of these boundaries
+  # One decimal number indicates one set of constrained components:
+  # 1-x, 2-y, 3-xy, 4-z, 5-xz, 6-yz, 7-xyz
+  # To make sense of the numbering, convert decimals to binaries (zyx)
+  set Dirichlet boundary components = 1, 1, 2, 2
+
+  # Specify the values of the Dirichlet BCs, including both homogeneous and
+  # inhomogeneous ones.
+  set Dirichlet boundary values = 0, 0, 0, 0
+end
+
+subsection Fluid Neumann BCs
+  # Number of boundaries with Neumann BCs (specificaly, pressure BC)
+  # Note: do-nothing (zero pressure) boundary do not need to be explicitly specified!)
+  set Number of Neumann BCs = 0
+
+  # List all the boundaries with Neumann BCs
+  set Neumann boundary id = 0
+
+  #Specify the values of the pressure of the Neumann BCs
+  set Neumann boundary values = 10
+end
+
+# --------------------------------------------------------------------------------
+# Solid solver
+subsection Solid finite element system
+  # The polynomial degree of solid element
+  set Degree = 1
+end
+
+subsection Solid material properties
+  # Material type, currently LinearElastic and NeoHookean are available
+  set Solid type = LinearElastic
+
+  # Solid density, used by all solid solvers
+  set Solid density = 1
+
+  # E, nu and eta are only used by linearElasticMaterial
+  set Young's modulus = 2.5
+
+  set Poisson's ratio = 0.25
+
+  set Viscosity = 0.0
+
+  # A list of parameters used by hyperelasticMaterial
+  set Hyperelastic parameters = 0.5, 1.67
+end
+
+subsection Solid solver control
+  # Artifitial damping. 
+  # -alpha for HHT-alpha time integraion (In MPI::SharedLinearLeasticity). 0 < -alpha < 0.3.
+  # For other solid solvers, this is the value added to 0.5 for gamma.
+  set Damping = 0.0
+
+  # Number of Newton-Raphson iterations allowed, used by hyperelastic solver only
+  set Max Newton iterations = 10
+
+  # Displacement error tolerance (relative to the first iteration at each timestep)
+  set Displacement tolerance  = 1.0e-6
+
+  # Force residual tolerance (relative to the first iteration at each timestep)
+  set Force tolerance  = 1.0e-6
+
+  # Contact force multiplier (only used in FSI)
+  set Contact force multiplier = 1.0e8
+end
+
+# Only homogeneous Dirichlet BC is supported, i.e., the prescribed value is always 0.
+subsection Solid Dirichlet BCs
+  # Dirichlet BCs can be applied to multiple boundaries.
+  set Number of Dirichlet BCs = 0
+
+  # List all the constrained boundaries here
+  set Dirichlet boundary id = 0
+
+  # List the constrained components of these boundaries
+  # One decimal number indicates one set of constrained components:
+  # 1-x, 2-y, 3-xy, 4-z, 5-xz, 6-yz, 7-xyz
+  # To make sense of the numbering, convert decimals to binaries (zyx)
+  set Dirichlet boundary components = 3
+end
+
+# Two types of Neumann BCs are supported: traction and pressure.
+# Pressure is defined w.r.t. the reference configuration.
+# (Original normal vectors are used to compute the traction.)
+subsection Solid Neumann BCs
+  # Indicates how many sets of Neumann boundary conditions to expect.
+  set Number of Neumann BCs = 0
+
+  # The id, type, and values must appear n_neumann_bcs times.
+  set Neumann boundary id = 3
+
+  # Traction/Pressure, currently they cannot coexist.
+  set Neumann boundary type = Traction
+
+  # If traction, dim*n_solid_neumann_bcs components are expected;
+  # if pressure, n_solid_neumann_bcs components are expected.
+  set Neumann boundary values = 0, -1e-4
+end

--- a/tests/fluid_initial_condition_mpi/fluid_initial_condition_mpi.cpp
+++ b/tests/fluid_initial_condition_mpi/fluid_initial_condition_mpi.cpp
@@ -1,0 +1,87 @@
+/**
+ * This program tests parallel NavierStokes solver with a 2D flow around
+ * cylinder
+ * case.
+ * Hard-coded parabolic velocity input is used, and Re = 20.
+ * Only one step is run, and the test takes about 33s.
+ */
+#include "mpi_scnsim.h"
+#include "parameters.h"
+#include "utilities.h"
+
+extern template class Fluid::MPI::SCnsIM<2>;
+extern template class Fluid::MPI::SCnsIM<3>;
+
+using namespace dealii;
+
+int main(int argc, char *argv[])
+{
+  try
+    {
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+      std::string infile("parameters.prm");
+      if (argc > 1)
+        {
+          infile = argv[1];
+        }
+      Parameters::AllParameters params(infile);
+
+      if (params.dimension == 2)
+        {
+          auto initial_condition = [](const Point<2> &point,
+                                      const unsigned int component) -> double {
+            double pressure = 1e4;
+            if (component == 2)
+              {
+                if (point[0] > 4.0 && point[0] < 5.0)
+                  {
+                    return pressure * (point[0] - 4.0);
+                  }
+                else if (point[0] >= 5.0 && point[0] < 12.0)
+                  {
+                    return pressure;
+                  }
+              }
+            return 0.0;
+          };
+          parallel::distributed::Triangulation<2> tria(MPI_COMM_WORLD);
+          GridGenerator::subdivided_hyper_rectangle(
+            tria, {150, 20}, Point<2>(0, 0), Point<2>(15, 2), true);
+          Fluid::MPI::SCnsIM<2> flow(tria, params);
+          flow.set_initial_condition(initial_condition);
+          flow.run();
+          // Check the max values of velocity and pressure
+        }
+      else
+        {
+          AssertThrow(false, ExcMessage("This test should be run in 2D!"));
+        }
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  return 0;
+}

--- a/tests/fluid_initial_condition_mpi/fluid_initial_condition_mpi.prm
+++ b/tests/fluid_initial_condition_mpi/fluid_initial_condition_mpi.prm
@@ -1,0 +1,179 @@
+# This is the input file for the program. There are three blocks of input parameters,
+# namely the simulation block, which contorls the simulation parameters shared by
+# both fluid and solid, such as the simulation time, output frequency and so on.
+# The fluid block controls the behavior of the fluid solver, and the solid solver
+# controls the solid solver.
+#
+# --------------------------------------------------------------------------------
+# Simulation parameters
+subsection Simulation
+  # Type of simulation: FSI/Fluid/Solid
+  set Simulation type = Fluid
+
+  # The dimension of the simulation
+  set Dimension = 2
+
+  # Level of global refinement before running,
+  # which applies to all the solvers
+  set Global refinements = 0, 0
+
+  # The end time of the simulation in second
+  set End time = 1e-11
+
+  # The time step in second
+  set Time step size = 1e-11
+
+  # The output interval in second
+  set Output interval = 1e-11
+
+  # Mesh refinement interval in second
+  set Refinement interval = 10
+
+  # Checkpoint save interval in second
+  set Save interval = 1e-1
+
+  # Body force which applies to solid only (acceleration)
+  set Gravity = 0.0, 0.0
+end
+
+# --------------------------------------------------------------------------------
+# Fluid solver
+subsection Fluid finite element system
+  # The degree of pressure element
+  set Pressure degree = 1
+
+  # The degree of velocity element. For grad-div solver this must be one higher than pressure
+  set Velocity degree = 1
+end
+
+subsection Fluid material properties
+  # The dynamic viscosity
+  set Dynamic viscosity = 1.8e-4
+
+  # Fluid density
+  set Fluid density = 1.3e-3
+end
+
+subsection Fluid solver control
+  # The global Grad-Div stabilization, empirically should be in [0.1, 1]
+  set Grad-Div stabilization = 0.1
+
+  # Maximum number of Newton iterations at a time step
+  set Max Newton iterations = 8
+
+  # The relative tolerance of the nonlinear system residual
+  set Nonlinear system tolerance = 1e-6
+end
+
+subsection Fluid Dirichlet BCs
+  # Use the hard-coded boundary values or the input values.
+  # Note: even if this variable is set to 1, the following 3 variables
+  # will still be used so that the hard-coded values BCs applies to the
+  # target boundaries and directions only.
+  set Use hard-coded boundary values = 0
+
+  # Number of boundaries with Dirichlet BCs
+  set Number of Dirichlet BCs = 4
+
+  # List all the boundaries with Dirichlet BCs
+  set Dirichlet boundary id = 0, 1, 2, 3
+
+  # List the constrained components of these boundaries
+  # One decimal number indicates one set of constrained components:
+  # 1-x, 2-y, 3-xy, 4-z, 5-xz, 6-yz, 7-xyz
+  # To make sense of the numbering, convert decimals to binaries (zyx)
+  set Dirichlet boundary components = 1, 1, 2, 2
+
+  # Specify the values of the Dirichlet BCs, including both homogeneous and
+  # inhomogeneous ones.
+  set Dirichlet boundary values = 0, 0, 0, 0
+end
+
+subsection Fluid Neumann BCs
+  # Number of boundaries with Neumann BCs (specificaly, pressure BC)
+  # Note: do-nothing (zero pressure) boundary do not need to be explicitly specified!)
+  set Number of Neumann BCs = 0
+
+  # List all the boundaries with Neumann BCs
+  set Neumann boundary id = 0
+
+  #Specify the values of the pressure of the Neumann BCs
+  set Neumann boundary values = 10
+end
+
+# --------------------------------------------------------------------------------
+# Solid solver
+subsection Solid finite element system
+  # The polynomial degree of solid element
+  set Degree = 1
+end
+
+subsection Solid material properties
+  # Material type, currently LinearElastic and NeoHookean are available
+  set Solid type = LinearElastic
+
+  # Solid density, used by all solid solvers
+  set Solid density = 1
+
+  # E, nu and eta are only used by linearElasticMaterial
+  set Young's modulus = 2.5
+
+  set Poisson's ratio = 0.25
+
+  set Viscosity = 0.0
+
+  # A list of parameters used by hyperelasticMaterial
+  set Hyperelastic parameters = 0.5, 1.67
+end
+
+subsection Solid solver control
+  # Artifitial damping. 
+  # -alpha for HHT-alpha time integraion (In MPI::SharedLinearLeasticity). 0 < -alpha < 0.3.
+  # For other solid solvers, this is the value added to 0.5 for gamma.
+  set Damping = 0.0
+
+  # Number of Newton-Raphson iterations allowed, used by hyperelastic solver only
+  set Max Newton iterations = 10
+
+  # Displacement error tolerance (relative to the first iteration at each timestep)
+  set Displacement tolerance  = 1.0e-6
+
+  # Force residual tolerance (relative to the first iteration at each timestep)
+  set Force tolerance  = 1.0e-6
+
+  # Contact force multiplier (only used in FSI)
+  set Contact force multiplier = 1.0e8
+end
+
+# Only homogeneous Dirichlet BC is supported, i.e., the prescribed value is always 0.
+subsection Solid Dirichlet BCs
+  # Dirichlet BCs can be applied to multiple boundaries.
+  set Number of Dirichlet BCs = 0
+
+  # List all the constrained boundaries here
+  set Dirichlet boundary id = 0
+
+  # List the constrained components of these boundaries
+  # One decimal number indicates one set of constrained components:
+  # 1-x, 2-y, 3-xy, 4-z, 5-xz, 6-yz, 7-xyz
+  # To make sense of the numbering, convert decimals to binaries (zyx)
+  set Dirichlet boundary components = 3
+end
+
+# Two types of Neumann BCs are supported: traction and pressure.
+# Pressure is defined w.r.t. the reference configuration.
+# (Original normal vectors are used to compute the traction.)
+subsection Solid Neumann BCs
+  # Indicates how many sets of Neumann boundary conditions to expect.
+  set Number of Neumann BCs = 0
+
+  # The id, type, and values must appear n_neumann_bcs times.
+  set Neumann boundary id = 3
+
+  # Traction/Pressure, currently they cannot coexist.
+  set Neumann boundary type = Traction
+
+  # If traction, dim*n_solid_neumann_bcs components are expected;
+  # if pressure, n_solid_neumann_bcs components are expected.
+  set Neumann boundary values = 0, -1e-4
+end

--- a/tests/fsi_contact_model_mpi/fsi_contact_model_mpi.cpp
+++ b/tests/fsi_contact_model_mpi/fsi_contact_model_mpi.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[])
           Fluid::MPI::SCnsIM<2> fluid(tria_fluid, params);
           Solid::MPI::SharedLinearElasticity<2> solid(tria_solid, params);
 
-          auto penetration_criterion = [](const Point<2> p) -> double {
+          auto penetration_criterion = [](const Point<2> &p) -> double {
             double wall_height = 1.0;
             return (p[1] - wall_height);
           };


### PR DESCRIPTION
- Use macros for `using` phrases in `MPI::FluidSolver<dim>`  and `MPI::SharedSolidSolver<dim>`
For example:
```c++
#define MPIFluidSolverInheritanceMacro()                                       \
public:                                                                        \
  using FluidSolver<dim>::add_hard_coded_boundary_condition;                   \
  using FluidSolver<dim>::set_body_force;                                      \
  using FluidSolver<dim>::set_sigma_pml_field;                                 \
  using FluidSolver<dim>::set_initial_condition;                               \
.........
```

- Add custom modules for `MPI::FluidSolver`:
  * Add `MPI::FluidSolver::set_initial_condition()`
  * Add `MPI::FluidSolver::set_body_force()`
  * Add `MPI::FluidSolver::set_sigma_pml_field()`

- Add 2 cmake tests for initial condition and body force, respectively.
- Rename `MPI::FluidSolver::BoundaryValues` to `MPI::FluidSolver::Field` because they are now also used for sigma PML and body force fields