### PR TITLE
add cell stress output for the linear elasticity solver

### DIFF
--- a/include/inheritance_macros.h
+++ b/include/inheritance_macros.h
@@ -58,6 +58,7 @@ private:                                                                       \
 
 #define MPISharedSolidSolverInheritanceMacro()                                 \
 private:                                                                       \
+  using SharedSolidSolver<dim>::cellwise_stress;                               \
   using SharedSolidSolver<dim>::triangulation;                                 \
   using SharedSolidSolver<dim>::parameters;                                    \
   using SharedSolidSolver<dim>::dof_handler;                                   \

--- a/include/linear_elasticity.h
+++ b/include/linear_elasticity.h
@@ -67,9 +67,7 @@ namespace Solid
     using SolidSolver<dim>::previous_displacement;
     using SolidSolver<dim>::strain;
     using SolidSolver<dim>::stress;
-    using SolidSolver<dim>::cellwise_sxx;
-    using SolidSolver<dim>::cellwise_sxy;
-    using SolidSolver<dim>::cellwise_syy;
+    using SolidSolver<dim>::cellwise_stress;
     using SolidSolver<dim>::time;
     using SolidSolver<dim>::timer;
     using SolidSolver<dim>::cell_property;

--- a/include/linear_elasticity.h
+++ b/include/linear_elasticity.h
@@ -67,6 +67,9 @@ namespace Solid
     using SolidSolver<dim>::previous_displacement;
     using SolidSolver<dim>::strain;
     using SolidSolver<dim>::stress;
+    using SolidSolver<dim>::cellwise_sxx;
+    using SolidSolver<dim>::cellwise_sxy;
+    using SolidSolver<dim>::cellwise_syy;
     using SolidSolver<dim>::time;
     using SolidSolver<dim>::timer;
     using SolidSolver<dim>::cell_property;

--- a/include/mpi_shared_linear_elasticity.h
+++ b/include/mpi_shared_linear_elasticity.h
@@ -55,6 +55,10 @@ namespace Solid
        * Assembles lhs and rhs. At time step 0, the lhs is the mass matrix;
        * at all the following steps, it is \f$ M + \beta{\Delta{t}}^2K \f$.
        */
+      using SharedSolidSolver<dim>::cellwise_sxx;
+      using SharedSolidSolver<dim>::cellwise_sxy;
+      using SharedSolidSolver<dim>::cellwise_syy;
+
       void assemble_system(bool is_initial);
 
       /**

--- a/include/mpi_shared_linear_elasticity.h
+++ b/include/mpi_shared_linear_elasticity.h
@@ -55,9 +55,6 @@ namespace Solid
        * Assembles lhs and rhs. At time step 0, the lhs is the mass matrix;
        * at all the following steps, it is \f$ M + \beta{\Delta{t}}^2K \f$.
        */
-      using SharedSolidSolver<dim>::cellwise_sxx;
-      using SharedSolidSolver<dim>::cellwise_sxy;
-      using SharedSolidSolver<dim>::cellwise_syy;
 
       void assemble_system(bool is_initial);
 

--- a/include/mpi_shared_solid_solver.h
+++ b/include/mpi_shared_solid_solver.h
@@ -201,8 +201,7 @@ namespace Solid
        */
       mutable std::vector<std::vector<PETScWrappers::MPI::Vector>> strain,
         stress;
-      //mutable PETScWrappers::MPI::Vector cellwise_sxx, cellwise_sxy,cellwise_syy;
-      mutable Vector <double> cellwise_sxx, cellwise_sxy,cellwise_syy;
+      mutable std::vector<Vector<double>> cellwise_stress;
       MPI_Comm mpi_communicator;
       const unsigned int n_mpi_processes;
       const unsigned int this_mpi_process;

--- a/include/mpi_shared_solid_solver.h
+++ b/include/mpi_shared_solid_solver.h
@@ -201,7 +201,8 @@ namespace Solid
        */
       mutable std::vector<std::vector<PETScWrappers::MPI::Vector>> strain,
         stress;
-
+      //mutable PETScWrappers::MPI::Vector cellwise_sxx, cellwise_sxy,cellwise_syy;
+      mutable Vector <double> cellwise_sxx, cellwise_sxy,cellwise_syy;
       MPI_Comm mpi_communicator;
       const unsigned int n_mpi_processes;
       const unsigned int this_mpi_process;

--- a/include/solid_solver.h
+++ b/include/solid_solver.h
@@ -163,6 +163,8 @@ namespace Solid
      */
     mutable std::vector<std::vector<Vector<double>>> strain, stress;
 
+    mutable Vector <double> cellwise_sxx, cellwise_sxy,cellwise_syy;
+
     Utils::Time time;
     mutable TimerOutput timer;
 

--- a/include/solid_solver.h
+++ b/include/solid_solver.h
@@ -162,8 +162,7 @@ namespace Solid
      * denotes sigma_{ij} at vertex k.
      */
     mutable std::vector<std::vector<Vector<double>>> strain, stress;
-
-    mutable Vector <double> cellwise_sxx, cellwise_sxy,cellwise_syy;
+    mutable std::vector<Vector<double>> cellwise_stress;
 
     Utils::Time time;
     mutable TimerOutput timer;

--- a/source/linear_elasticity.cpp
+++ b/source/linear_elasticity.cpp
@@ -372,8 +372,16 @@ namespace Solid
     auto cell = dof_handler.begin_active();
     auto scalar_cell = scalar_dof_handler.begin_active();
     std::vector<types::global_dof_index> dof_indices(scalar_fe.dofs_per_cell);
+
+    // containers for cell-wise stress output
+    cellwise_sxx.reinit(triangulation.n_active_cells());
+    cellwise_sxy.reinit(triangulation.n_active_cells());
+    cellwise_syy.reinit(triangulation.n_active_cells());
+
+
     for (; cell != dof_handler.end(); ++cell, ++scalar_cell)
       {
+        std::vector <double> ele_stress {0.0,0.0,0.0,0.0};
         scalar_cell->get_dof_indices(dof_indices);
         fe_values.reinit(cell);
         fe_values[displacements].get_function_gradients(
@@ -405,7 +413,17 @@ namespace Solid
                     quad_stress[i][j][q] = tmp_stress[i][j];
                   }
               }
+              ele_stress[0] += (0.25*quad_stress[0][0][q]);
+	            ele_stress[1] += (0.25*quad_stress[0][1][q]);
+	            ele_stress[2] += (0.25*quad_stress[1][0][q]);
+	            ele_stress[3] += (0.25*quad_stress[1][1][q]);
           }
+           
+         
+           cellwise_sxx[cell->active_cell_index()] = ele_stress[0];
+           cellwise_sxy[cell->active_cell_index()] = ele_stress[1];
+           cellwise_syy[cell->active_cell_index()] = ele_stress[3];
+
 
         for (unsigned int i = 0; i < dim; ++i)
           {
@@ -435,7 +453,9 @@ namespace Solid
               }
           }
       }
+
   }
+
 
   template class LinearElasticity<2>;
   template class LinearElasticity<3>;

--- a/source/mpi_shared_linear_elasticity.cpp
+++ b/source/mpi_shared_linear_elasticity.cpp
@@ -446,19 +446,19 @@ namespace Solid
 
       Vector<double> localized_current_displacement(current_displacement);
 
-      // containers for cell-wise stress output
-      cellwise_sxx.reinit(triangulation.n_active_cells());
-      cellwise_sxy.reinit(triangulation.n_active_cells());
-      cellwise_syy.reinit(triangulation.n_active_cells());
+      for (unsigned int i = 0; i < cellwise_stress.size(); ++i)
+        {
+          cellwise_stress[i].reinit(triangulation.n_active_cells());
+        }
 
       for (; cell != dof_handler.end(); ++cell, ++scalar_cell)
         {
           if (cell->subdomain_id() == this_mpi_process)
             {
-              std::vector <double> ele_stress {0.0,0.0,0.0,0.0};
+              std::vector<double> tmp_cell_stress(6, 0.0);
               fe_values.reinit(cell);
               fe_values[displacements].get_function_gradients(
-              localized_current_displacement, current_displacement_gradients);
+                localized_current_displacement, current_displacement_gradients);
               int mat_id = cell->material_id();
               if (parameters.n_solid_parts == 1)
                 mat_id = 1;
@@ -486,15 +486,23 @@ namespace Solid
                           quad_stress[i][j][q] = tmp_stress[i][j];
                         }
                     }
-                    ele_stress[0] += (0.25*quad_stress[0][0][q]);
-	                  ele_stress[1] += (0.25*quad_stress[0][1][q]);
-	                  ele_stress[2] += (0.25*quad_stress[1][0][q]);
-	                  ele_stress[3] += (0.25*quad_stress[1][1][q]);
+                  tmp_cell_stress[0] += (0.25 * quad_stress[0][0][q]);
+                  tmp_cell_stress[1] += (0.25 * quad_stress[0][1][q]);
+                  tmp_cell_stress[2] += (0.25 * quad_stress[1][1][q]);
+
+                  if (dim == 3)
+                    {
+                      tmp_cell_stress[3] += (0.25 * quad_stress[0][2][q]);
+                      tmp_cell_stress[4] += (0.25 * quad_stress[1][2][q]);
+                      tmp_cell_stress[5] += (0.25 * quad_stress[2][2][q]);
+                    }
                 }
 
-                  cellwise_sxx[cell->active_cell_index()] = ele_stress[0];
-                  cellwise_sxy[cell->active_cell_index()] = ele_stress[1];
-                  cellwise_syy[cell->active_cell_index()] = ele_stress[3];
+              for (unsigned int i = 0; i < cellwise_stress.size(); ++i)
+                {
+                  cellwise_stress[i][cell->active_cell_index()] =
+                    tmp_cell_stress[i];
+                }
               for (unsigned int i = 0; i < dim; ++i)
                 {
                   for (unsigned int j = 0; j < dim; ++j)

--- a/source/mpi_shared_solid_solver.cpp
+++ b/source/mpi_shared_solid_solver.cpp
@@ -162,6 +162,10 @@ namespace Solid
           spacedim,
           PETScWrappers::MPI::Vector(locally_owned_scalar_dofs,
                                      mpi_communicator)));
+      
+    cellwise_sxx.reinit(triangulation.n_active_cells());
+    cellwise_sxy.reinit(triangulation.n_active_cells());
+    cellwise_syy.reinit(triangulation.n_active_cells());
     }
 
     // Solve linear system \f$Ax = b\f$ using CG solver.
@@ -283,6 +287,10 @@ namespace Solid
               data_out.add_data_vector(
                 scalar_dof_handler, localized_stress[2][2], "Szz");
             }
+    //cell strain and stress
+    data_out.add_data_vector (cellwise_sxx, "cell_sxx"); 
+    data_out.add_data_vector (cellwise_sxy, "cell_sxy"); 
+    data_out.add_data_vector (cellwise_syy, "cell_syy"); 
 
           data_out.build_patches();
 

--- a/source/mpi_shared_solid_solver.cpp
+++ b/source/mpi_shared_solid_solver.cpp
@@ -162,10 +162,14 @@ namespace Solid
           spacedim,
           PETScWrappers::MPI::Vector(locally_owned_scalar_dofs,
                                      mpi_communicator)));
-      
-    cellwise_sxx.reinit(triangulation.n_active_cells());
-    cellwise_sxy.reinit(triangulation.n_active_cells());
-    cellwise_syy.reinit(triangulation.n_active_cells());
+
+      cellwise_stress = std::vector<Vector<double>>(
+        6, Vector<double>(triangulation.n_active_cells()));
+
+      for (unsigned int i = 0; i < cellwise_stress.size(); ++i)
+        {
+          cellwise_stress[i].reinit(triangulation.n_active_cells());
+        }
     }
 
     // Solve linear system \f$Ax = b\f$ using CG solver.
@@ -272,6 +276,10 @@ namespace Solid
             scalar_dof_handler, localized_stress[0][1], "Sxy");
           data_out.add_data_vector(
             scalar_dof_handler, localized_stress[1][1], "Syy");
+
+          data_out.add_data_vector(cellwise_stress[0], "cell_sxx");
+          data_out.add_data_vector(cellwise_stress[1], "cell_sxy");
+          data_out.add_data_vector(cellwise_stress[2], "cell_syy");
           if (spacedim == 3)
             {
               data_out.add_data_vector(
@@ -286,11 +294,10 @@ namespace Solid
                 scalar_dof_handler, localized_stress[1][2], "Syz");
               data_out.add_data_vector(
                 scalar_dof_handler, localized_stress[2][2], "Szz");
+              data_out.add_data_vector(cellwise_stress[3], "cell_sxz");
+              data_out.add_data_vector(cellwise_stress[4], "cell_syz");
+              data_out.add_data_vector(cellwise_stress[5], "cell_szz");
             }
-    //cell strain and stress
-    data_out.add_data_vector (cellwise_sxx, "cell_sxx"); 
-    data_out.add_data_vector (cellwise_sxy, "cell_sxy"); 
-    data_out.add_data_vector (cellwise_syy, "cell_syy"); 
 
           data_out.build_patches();
 

--- a/source/solid_solver.cpp
+++ b/source/solid_solver.cpp
@@ -111,9 +111,13 @@ namespace Solid
       std::vector<Vector<double>>(spacedim,
                                   Vector<double>(scalar_dof_handler.n_dofs())));
 
-    cellwise_sxx.reinit(triangulation.n_active_cells());
-    cellwise_sxy.reinit(triangulation.n_active_cells());
-    cellwise_syy.reinit(triangulation.n_active_cells());
+    cellwise_stress = std::vector<Vector<double>>(
+      6, Vector<double>(triangulation.n_active_cells()));
+
+    for (unsigned int i = 0; i < cellwise_stress.size(); ++i)
+      {
+        cellwise_stress[i].reinit(triangulation.n_active_cells());
+      }
 
     // Set up cell property, which contains the FSI traction required in FSI
     // simulation
@@ -184,6 +188,9 @@ namespace Solid
     data_out.add_data_vector(scalar_dof_handler, stress[0][0], "Sxx");
     data_out.add_data_vector(scalar_dof_handler, stress[0][1], "Sxy");
     data_out.add_data_vector(scalar_dof_handler, stress[1][1], "Syy");
+    data_out.add_data_vector(cellwise_stress[0], "cell_sxx");
+    data_out.add_data_vector(cellwise_stress[1], "cell_sxy");
+    data_out.add_data_vector(cellwise_stress[2], "cell_syy");
     if (spacedim == 3)
       {
         data_out.add_data_vector(scalar_dof_handler, strain[0][2], "Exz");
@@ -192,12 +199,10 @@ namespace Solid
         data_out.add_data_vector(scalar_dof_handler, stress[0][2], "Sxz");
         data_out.add_data_vector(scalar_dof_handler, stress[1][2], "Syz");
         data_out.add_data_vector(scalar_dof_handler, stress[2][2], "Szz");
+        data_out.add_data_vector(cellwise_stress[3], "cell_sxz");
+        data_out.add_data_vector(cellwise_stress[4], "cell_syz");
+        data_out.add_data_vector(cellwise_stress[5], "cell_szz");
       }
-
-    //cell strain and stress
-    data_out.add_data_vector (cellwise_sxx, "cell_sxx"); 
-    data_out.add_data_vector (cellwise_sxy, "cell_sxy"); 
-    data_out.add_data_vector (cellwise_syy, "cell_syy"); 
 
     data_out.build_patches();
 

--- a/source/solid_solver.cpp
+++ b/source/solid_solver.cpp
@@ -111,6 +111,10 @@ namespace Solid
       std::vector<Vector<double>>(spacedim,
                                   Vector<double>(scalar_dof_handler.n_dofs())));
 
+    cellwise_sxx.reinit(triangulation.n_active_cells());
+    cellwise_sxy.reinit(triangulation.n_active_cells());
+    cellwise_syy.reinit(triangulation.n_active_cells());
+
     // Set up cell property, which contains the FSI traction required in FSI
     // simulation
     cell_property.initialize(triangulation.begin_active(),
@@ -189,6 +193,11 @@ namespace Solid
         data_out.add_data_vector(scalar_dof_handler, stress[1][2], "Syz");
         data_out.add_data_vector(scalar_dof_handler, stress[2][2], "Szz");
       }
+
+    //cell strain and stress
+    data_out.add_data_vector (cellwise_sxx, "cell_sxx"); 
+    data_out.add_data_vector (cellwise_sxy, "cell_sxy"); 
+    data_out.add_data_vector (cellwise_syy, "cell_syy"); 
 
     data_out.build_patches();
 


### PR DESCRIPTION
Added the element stress output in serial and mpi-shared linear elasticity solver. Use test case solid_beam_bending to see the elemental stress output.