### PR TITLE
Optimize & fix bug for fluid stress interpolation

### DIFF
--- a/include/mpi_fsi.h
+++ b/include/mpi_fsi.h
@@ -15,6 +15,8 @@ extern template class Solid::MPI::SharedSolidSolver<2>;
 extern template class Solid::MPI::SharedSolidSolver<3>;
 extern template class Utils::GridInterpolator<2, Vector<double>>;
 extern template class Utils::GridInterpolator<3, Vector<double>>;
+extern template class Utils::GridInterpolator<2, PETScWrappers::MPI::Vector>;
+extern template class Utils::GridInterpolator<3, PETScWrappers::MPI::Vector>;
 extern template class Utils::GridInterpolator<2,
                                               PETScWrappers::MPI::BlockVector>;
 extern template class Utils::GridInterpolator<3,

--- a/source/fsi.cpp
+++ b/source/fsi.cpp
@@ -349,8 +349,16 @@ void FSI<dim>::find_solid_bc()
               Utils::GridInterpolator<dim, BlockVector<double>> interpolator(
                 fluid_solver.dof_handler, q_point);
               interpolator.point_value(fluid_solver.present_solution, value);
+              // Create the scalar interpolator for stresses based on the
+              // existing interpolator
+              auto f_cell = interpolator.get_cell();
+              TriaActiveIterator<DoFCellAccessor<DoFHandler<dim>, false>>
+                scalar_f_cell(&fluid_solver.triangulation,
+                              f_cell->level(),
+                              f_cell->index(),
+                              &fluid_solver.scalar_dof_handler);
               Utils::GridInterpolator<dim, Vector<double>> scalar_interpolator(
-                fluid_solver.scalar_dof_handler, q_point);
+                fluid_solver.scalar_dof_handler, q_point, {}, scalar_f_cell);
               SymmetricTensor<2, dim> viscous_stress;
               for (unsigned int i = 0; i < dim; i++)
                 {


### PR DESCRIPTION
- Fix bug in ``MPI::FSI::find_solid_bc()`` for direct interpolation on locally partitioned vectors (fluid stresses)
- Optimize ``FSI::find_solid_bc()`` and ``MPI::FSI::find_solid_bc()``

Comparison on fsi_leaflet case (serial) runningn 20 steps:
![image](https://user-images.githubusercontent.com/21187771/122127745-a39a0000-ce01-11eb-9bea-0fa919247d86.png)
time on find_solid_bc is halved.
