### PR TITLE
Add ctest fluid_cylinder_mpi_scnsim

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ set(mpi_tests acoustic_duct_wave_mpi
               acoustic_pml_mpi
               fluid_body_force_mpi
               fluid_cylinder_mpi
+              fluid_cylinder_mpi_scnsim
               fluid_cylinder_mpi_insimex
               fluid_initial_condition_mpi
               fluid_pipe_mpi

--- a/tests/fluid_cylinder_mpi_scnsim/fluid_cylinder_mpi_scnsim.cpp
+++ b/tests/fluid_cylinder_mpi_scnsim/fluid_cylinder_mpi_scnsim.cpp
@@ -1,0 +1,129 @@
+/**
+ * This program tests parallel NavierStokes solver with a 2D flow around
+ * cylinder
+ * case.
+ * Hard-coded parabolic velocity input is used, and Re = 20.
+ * Only one step is run, and the test takes about 33s.
+ */
+#include "mpi_scnsim.h"
+#include "parameters.h"
+#include "utilities.h"
+
+extern template class Fluid::MPI::SCnsIM<2>;
+extern template class Fluid::MPI::SCnsIM<3>;
+extern template class Utils::GridCreator<2>;
+extern template class Utils::GridCreator<3>;
+
+using namespace dealii;
+
+int main(int argc, char *argv[])
+{
+  try
+    {
+      Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+
+      std::string infile("parameters.prm");
+      if (argc > 1)
+        {
+          infile = argv[1];
+        }
+      Parameters::AllParameters params(infile);
+
+      auto inflow_bc = [dt = params.time_step](const Point<2> &p,
+                                               const unsigned int component,
+                                               const double time) -> double {
+        double left_boundary = 0.0;
+        unsigned int flow_component = 0;
+        if (component == flow_component &&
+            std::abs(p[flow_component] - left_boundary) < 1e-10 &&
+            time < 2 * dt)
+          {
+            // For a parabolic velocity profile, Uavg = 2/3 * Umax in
+            // 2D, and 4/9 * Umax in 3D. If nu = 1.8e-4, D = 1.3e-3, then Re
+            // = 7.22 * Uavg
+            double Uavg = 3;
+            double Umax = 3 * Uavg / 2;
+            double value = 4 * Umax * p[1] * (0.41 - p[1]) / (0.41 * 0.41);
+            return value;
+          }
+        return 0.0;
+      };
+
+      auto inflow_bc_3d = [dt = params.time_step](const Point<3> &p,
+                                                  const unsigned int component,
+                                                  const double time) -> double {
+        double left_boundary = -0.3;
+        unsigned int flow_component = 2;
+        if (component == flow_component &&
+            std::abs(p[flow_component] - left_boundary) < 1e-10 &&
+            time < 2 * dt)
+          {
+            // For a parabolic velocity profile, Uavg = 2/3 * Umax in
+            // 2D, and 4/9 * Umax in 3D. If nu = 1.8e-4, D = 1.3e-3, then Re
+            // = 7.22 * Uavg
+            double Uavg = 3;
+            double Umax = 9 * Uavg / 4;
+            double value = 4 * Umax * p[1] * (0.41 - p[1]) / (0.41 * 0.41);
+            value *= 4 * p[2] * (0.41 - p[2]) / (0.41 * 0.41);
+            return value;
+          }
+        return 0.0;
+      };
+
+      if (params.dimension == 2)
+        {
+          parallel::distributed::Triangulation<2> tria(MPI_COMM_WORLD);
+          Utils::GridCreator<2>::flow_around_cylinder(tria);
+          Fluid::MPI::SCnsIM<2> flow(tria, params);
+          flow.add_hard_coded_boundary_condition(0, inflow_bc);
+          flow.run();
+          // Check the max values of velocity and pressure
+          auto solution = flow.get_current_solution();
+          auto v = solution.block(0), p = solution.block(1);
+          double vmax = Utils::PETScVectorMax(v);
+          double pmax = Utils::PETScVectorMax(p);
+          double verror = std::abs(vmax - 4.5) / 4.5;
+          double perror = std::abs(pmax - 1.03544) / 1.03544;
+          AssertThrow(verror < 1e-3 && perror < 1e-3,
+                      ExcMessage("Maximum velocity or pressure is incorrect!"));
+        }
+      else if (params.dimension == 3)
+        {
+          parallel::distributed::Triangulation<3> tria(MPI_COMM_WORLD);
+          Utils::GridCreator<3>::flow_around_cylinder(tria);
+          Fluid::MPI::SCnsIM<3> flow(tria, params);
+          flow.add_hard_coded_boundary_condition(4, inflow_bc_3d);
+          flow.run();
+        }
+      else
+        {
+          AssertThrow(false, ExcMessage("This test should be run in 2D!"));
+        }
+    }
+  catch (std::exception &exc)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Exception on processing: " << std::endl
+                << exc.what() << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  catch (...)
+    {
+      std::cerr << std::endl
+                << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      std::cerr << "Unknown exception!" << std::endl
+                << "Aborting!" << std::endl
+                << "----------------------------------------------------"
+                << std::endl;
+      return 1;
+    }
+  return 0;
+}

--- a/tests/fluid_cylinder_mpi_scnsim/fluid_cylinder_mpi_scnsim.prm
+++ b/tests/fluid_cylinder_mpi_scnsim/fluid_cylinder_mpi_scnsim.prm
@@ -1,0 +1,172 @@
+# This is the input file for the program. There are three blocks of input parameters,
+# namely the simulation block, which contorls the simulation parameters shared by
+# both fluid and solid, such as the simulation time, output frequency and so on.
+# The fluid block controls the behavior of the fluid solver, and the solid solver
+# controls the solid solver.
+#
+# --------------------------------------------------------------------------------
+# Simulation parameters
+subsection Simulation
+  # Type of simulation: FSI/Fluid/Solid
+  set Simulation type =  Fluid
+
+  # The dimension of the simulation
+  set Dimension = 2
+
+  # Level of global refinement before running,
+  # which applies to all the solvers
+  set Global refinements = 3, 0
+
+  # The end time of the simulation in second
+  set End time = 1e-2
+
+  # The time step in second
+  set Time step size = 1e-2
+
+  # The output interval in second
+  set Output interval = 1e-2
+
+  # Mesh refinement interval in second
+  set Refinement interval = 100
+
+  # Checkpoint save interval in second
+  set Save interval = 100
+
+  # Body force which applies to both fluid and solid (acceleration)
+  set Gravity = 0.0, 0.0
+end
+
+# --------------------------------------------------------------------------------
+# Fluid solver
+subsection Fluid finite element system
+  # The degree of pressure element
+  set Pressure degree = 1
+
+  # The degree of velocity element. For grad-div solver this must be one higher than pressure
+  set Velocity degree = 1
+end
+
+subsection Fluid material properties
+  # The dynamic viscosity
+  set Dynamic viscosity = 1.8e-4
+
+  # Fluid density
+  set Fluid density = 1.3e-3
+end
+
+subsection Fluid solver control
+  # The global Grad-Div stabilization, empirically should be in [0.1, 1]
+  set Grad-Div stabilization = 0.1
+
+  # Maximum number of Newton iterations at a time step
+  set Max Newton iterations = 8
+
+  # The relative tolerance of the nonlinear system residual
+  set Nonlinear system tolerance = 1e-6
+end
+
+subsection Fluid Dirichlet BCs
+  # Use the hard-coded boundary values or the input values.
+  # Note: even if this variable is set to 1, the following 3 variables
+  # will still be used so that the hard-coded values BCs applies to the
+  # target boundaries and directions only.
+  set Use hard-coded boundary values = 1
+
+  # Number of boundaries with Dirichlet BCs
+  set Number of Dirichlet BCs = 4
+
+  # List all the boundaries with Dirichlet BCs
+  set Dirichlet boundary id = 0, 2, 3, 4
+
+  # List the constrained components of these boundaries
+  # One decimal number indicates one set of constrained components:
+  # 1-x, 2-y, 3-xy, 4-z, 5-xz, 6-yz, 7-xyz
+  # To make sense of the numbering, convert decimals to binaries (zyx)
+  set Dirichlet boundary components = 3, 3, 3, 3
+
+  # Specify the values of the Dirichlet BCs, including both homogeneous and
+  # inhomogeneous ones.
+  set Dirichlet boundary values = 0.2, 0, 0, 0, 0, 0, 0, 0
+end
+
+subsection Fluid Neumann BCs
+  # Number of boundaries with Neumann BCs (specificaly, pressure BC)
+  # Note: do-nothing (zero pressure) boundary do not need to be explicitly specified!)
+  set Number of Neumann BCs = 0
+
+  # List all the boundaries with Neumann BCs
+  set Neumann boundary id = 0
+
+  #Specify the values of the pressure of the Neumann BCs
+  set Neumann boundary values = 10
+end
+
+# --------------------------------------------------------------------------------
+# Solid solver
+subsection Solid finite element system
+  # The polynomial degree of solid element
+  set Degree = 1
+end
+
+subsection Solid material properties
+  # Material type, currently LinearElastic and NeoHookean are available
+  set Solid type = LinearElastic
+
+  # Solid density, used by all solid solvers
+  set Solid density = 1
+
+  # E and nu are only used by linearElasticMaterial
+  set Young's modulus = 2.5
+
+  set Poisson's ratio = 0.25
+
+  # A list of parameters used by hyperelasticMaterial
+  set Hyperelastic parameters = 0.5, 1.67
+end
+
+subsection Solid solver control
+  # Artifitial damping.
+  set Damping = 0.0
+
+  # Number of Newton-Raphson iterations allowed, used by hyperelastic solver only
+  set Max Newton iterations = 10
+
+  # Displacement error tolerance (relative to the first iteration at each timestep)
+  set Displacement tolerance  = 1.0e-6
+
+  # Force residual tolerance (relative to the first iteration at each timestep)
+  set Force tolerance  = 1.0e-6
+end
+
+# Only homogeneous Dirichlet BC is supported, i.e., the prescribed value is always 0.
+subsection Solid Dirichlet BCs
+  # Dirichlet BCs can be applied to multiple boundaries.
+  set Number of Dirichlet BCs = 0
+
+  # List all the constrained boundaries here
+  set Dirichlet boundary id = 0
+
+  # List the constrained components of these boundaries
+  # One decimal number indicates one set of constrained components:
+  # 1-x, 2-y, 3-xy, 4-z, 5-xz, 6-yz, 7-xyz
+  # To make sense of the numbering, convert decimals to binaries (zyx)
+  set Dirichlet boundary components = 3
+end
+
+# Two types of Neumann BCs are supported: traction and pressure.
+# Pressure is defined w.r.t. the reference configuration.
+# (Original normal vectors are used to compute the traction.)
+subsection Solid Neumann BCs
+  # Indicates how many sets of Neumann boundary conditions to expect.
+  set Number of Neumann BCs = 0
+
+  # The id, type, and values must appear n_neumann_bcs times.
+  set Neumann boundary id = 3
+
+  # Traction/Pressure, currently they cannot coexist.
+  set Neumann boundary type = Traction
+
+  # If traction, dim*n_solid_neumann_bcs components are expected;
+  # if pressure, n_solid_neumann_bcs components are expected.
+  set Neumann boundary values = 0, -1e-4
+end


### PR DESCRIPTION
There was a bug in ``fluid_cylinder_mpi`` test where the hard-coded BC ignores time and boundary condition increases over time. This fix makes sure the BC is only applied at the first time step.

Think the current way of applying hard-coded BC is still not optimal: the user needs to know exactly how BCs are applied differently in implicit and explicit solvers in order to get their hard-coded BC properly working. Need to improve it in the future.
@nsnanal can you review?