### PR TITLE
Optimize output

### DIFF
--- a/source/mpi_fluid_solver.cpp
+++ b/source/mpi_fluid_solver.cpp
@@ -522,26 +522,14 @@ namespace Fluid
       data_out.build_patches(parameters.fluid_pressure_degree);
 
       std::string basename =
-        "fluid" + Utilities::int_to_string(output_index, 6) + "-";
+        "fluid_" + Utilities::int_to_string(output_index, 6);
 
-      std::string filename =
-        basename +
-        Utilities::int_to_string(triangulation.locally_owned_subdomain(), 4) +
-        ".vtu";
-
-      std::ofstream output(filename);
-      data_out.write_vtu(output);
+      data_out.write_vtu_with_pvtu_record(
+        "./", "fluid", output_index, mpi_communicator, 6, 0);
 
       if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
         {
-          for (unsigned int i = 0;
-               i < Utilities::MPI::n_mpi_processes(mpi_communicator);
-               ++i)
-            {
-              times_and_names.push_back(
-                {time.current(),
-                 basename + Utilities::int_to_string(i, 4) + ".vtu"});
-            }
+          times_and_names.push_back({time.current(), basename + ".pvtu"});
           std::ofstream pvd_output("fluid.pvd");
           DataOutBase::write_pvd_record(pvd_output, times_and_names);
         }
@@ -637,16 +625,8 @@ namespace Fluid
               Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
             {
               std::string basename =
-                "fluid" + Utilities::int_to_string(time.get_timestep(), 6) +
-                "-";
-              for (unsigned int j = 0;
-                   j < Utilities::MPI::n_mpi_processes(mpi_communicator);
-                   ++j)
-                {
-                  times_and_names.push_back(
-                    {time.current(),
-                     basename + Utilities::int_to_string(j, 4) + ".vtu"});
-                }
+                "fluid_" + Utilities::int_to_string(time.get_timestep(), 6);
+              times_and_names.push_back({time.current(), basename + ".pvtu"});
             }
           if (i == Utilities::string_to_int(checkpoint_file.stem()))
             break;

--- a/source/mpi_shared_solid_solver.cpp
+++ b/source/mpi_shared_solid_solver.cpp
@@ -216,87 +216,90 @@ namespace Solid
               localized_stress[i][j] = stress[i][j];
             }
         }
+      std::vector<std::string> solution_names(spacedim, "displacements");
+      std::vector<DataComponentInterpretation::DataComponentInterpretation>
+        data_component_interpretation(
+          spacedim, DataComponentInterpretation::component_is_part_of_vector);
+      DataOut<dim, DoFHandler<dim, spacedim>> data_out;
+      data_out.attach_dof_handler(dof_handler);
+
+      // displacements
+      data_out.add_data_vector(
+        displacement,
+        solution_names,
+        DataOut<dim, DoFHandler<dim, spacedim>>::type_dof_data,
+        data_component_interpretation);
+
+      // velocity
+      solution_names = std::vector<std::string>(spacedim, "velocities");
+      data_out.add_data_vector(
+        velocity,
+        solution_names,
+        DataOut<dim, DoFHandler<dim, spacedim>>::type_dof_data,
+        data_component_interpretation);
+
+      std::vector<unsigned int> subdomain_int(triangulation.n_active_cells());
+      GridTools::get_subdomain_association(triangulation, subdomain_int);
+      Vector<float> subdomain(subdomain_int.begin(), subdomain_int.end());
+      data_out.add_data_vector(subdomain, "subdomain");
+
+      // material ID
+      Vector<float> mat(triangulation.n_active_cells());
+      for (auto cell = triangulation.begin_active();
+           cell != triangulation.end();
+           ++cell)
+        {
+          if (cell->subdomain_id() == this_mpi_process)
+            {
+              mat[cell->active_cell_index()] = cell->material_id();
+            }
+        }
+      data_out.add_data_vector(mat, "material_id");
+
+      data_out.add_data_vector(
+        scalar_dof_handler, localized_strain[0][0], "Exx");
+      data_out.add_data_vector(
+        scalar_dof_handler, localized_strain[0][1], "Exy");
+      data_out.add_data_vector(
+        scalar_dof_handler, localized_strain[1][1], "Eyy");
+      data_out.add_data_vector(
+        scalar_dof_handler, localized_stress[0][0], "Sxx");
+      data_out.add_data_vector(
+        scalar_dof_handler, localized_stress[0][1], "Sxy");
+      data_out.add_data_vector(
+        scalar_dof_handler, localized_stress[1][1], "Syy");
+      if (spacedim == 3)
+        {
+          data_out.add_data_vector(
+            scalar_dof_handler, localized_strain[0][2], "Exz");
+          data_out.add_data_vector(
+            scalar_dof_handler, localized_strain[1][2], "Eyz");
+          data_out.add_data_vector(
+            scalar_dof_handler, localized_strain[2][2], "Ezz");
+          data_out.add_data_vector(
+            scalar_dof_handler, localized_stress[0][2], "Sxz");
+          data_out.add_data_vector(
+            scalar_dof_handler, localized_stress[1][2], "Syz");
+          data_out.add_data_vector(
+            scalar_dof_handler, localized_stress[2][2], "Szz");
+        }
+
+      data_out.set_cell_selection(
+        [this](const typename Triangulation<dim>::cell_iterator &cell) {
+          return (cell->is_active() &&
+                  cell->subdomain_id() == this_mpi_process);
+        });
+      data_out.build_patches();
+
+      std::string basename =
+        "solid_" + Utilities::int_to_string(output_index, 6);
+
+      data_out.write_vtu_with_pvtu_record(
+        "./", "solid", output_index, mpi_communicator, 6, 0);
+
       if (this_mpi_process == 0)
         {
-          std::vector<std::string> solution_names(spacedim, "displacements");
-          std::vector<DataComponentInterpretation::DataComponentInterpretation>
-            data_component_interpretation(
-              spacedim,
-              DataComponentInterpretation::component_is_part_of_vector);
-          DataOut<dim, DoFHandler<dim, spacedim>> data_out;
-          data_out.attach_dof_handler(dof_handler);
-
-          // displacements
-          data_out.add_data_vector(
-            displacement,
-            solution_names,
-            DataOut<dim, DoFHandler<dim, spacedim>>::type_dof_data,
-            data_component_interpretation);
-
-          // velocity
-          solution_names = std::vector<std::string>(spacedim, "velocities");
-          data_out.add_data_vector(
-            velocity,
-            solution_names,
-            DataOut<dim, DoFHandler<dim, spacedim>>::type_dof_data,
-            data_component_interpretation);
-
-          std::vector<unsigned int> subdomain_int(
-            triangulation.n_active_cells());
-          GridTools::get_subdomain_association(triangulation, subdomain_int);
-          Vector<float> subdomain(subdomain_int.begin(), subdomain_int.end());
-          data_out.add_data_vector(subdomain, "subdomain");
-
-          // material ID
-          Vector<float> mat(triangulation.n_active_cells());
-          int i = 0;
-          for (auto cell = triangulation.begin_active();
-               cell != triangulation.end();
-               ++cell)
-            {
-              mat[i++] = cell->material_id();
-            }
-          data_out.add_data_vector(mat, "material_id");
-
-          data_out.add_data_vector(
-            scalar_dof_handler, localized_strain[0][0], "Exx");
-          data_out.add_data_vector(
-            scalar_dof_handler, localized_strain[0][1], "Exy");
-          data_out.add_data_vector(
-            scalar_dof_handler, localized_strain[1][1], "Eyy");
-          data_out.add_data_vector(
-            scalar_dof_handler, localized_stress[0][0], "Sxx");
-          data_out.add_data_vector(
-            scalar_dof_handler, localized_stress[0][1], "Sxy");
-          data_out.add_data_vector(
-            scalar_dof_handler, localized_stress[1][1], "Syy");
-          if (spacedim == 3)
-            {
-              data_out.add_data_vector(
-                scalar_dof_handler, localized_strain[0][2], "Exz");
-              data_out.add_data_vector(
-                scalar_dof_handler, localized_strain[1][2], "Eyz");
-              data_out.add_data_vector(
-                scalar_dof_handler, localized_strain[2][2], "Ezz");
-              data_out.add_data_vector(
-                scalar_dof_handler, localized_stress[0][2], "Sxz");
-              data_out.add_data_vector(
-                scalar_dof_handler, localized_stress[1][2], "Syz");
-              data_out.add_data_vector(
-                scalar_dof_handler, localized_stress[2][2], "Szz");
-            }
-
-          data_out.build_patches();
-
-          std::string basename =
-            "solid-" + Utilities::int_to_string(output_index, 6);
-
-          std::string filename = basename + ".vtu";
-
-          std::ofstream output(filename);
-          data_out.write_vtu(output);
-
-          times_and_names.push_back({time.current(), filename});
+          times_and_names.push_back({time.current(), basename + ".pvtu"});
           std::ofstream pvd_output("solid.pvd");
           DataOutBase::write_pvd_record(pvd_output, times_and_names);
         }
@@ -526,8 +529,8 @@ namespace Solid
               Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
             {
               std::string basename =
-                "solid-" + Utilities::int_to_string(time.get_timestep(), 6);
-              std::string filename = basename + ".vtu";
+                "solid_" + Utilities::int_to_string(time.get_timestep(), 6);
+              std::string filename = basename + ".pvtu";
 
               times_and_names.push_back({time.current(), filename});
             }


### PR DESCRIPTION
* Use ``.pvtu`` file format for fluid solver and shared solid solver; Reduce the size of ``.pvd`` output file
* Use parallel output for shared solid solver: potentially reduce the output time.

Test on solid solver (1 output call on DCS cluster)
Serial output:
Output results                7.993e-01s |  1.40e-01% |
Parallel output
Output results                1.922e-02s | 0.000e+00%|
@nsnanal Can you review?
