### PR TITLE
Fix several source comment and doc typos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 
 if(NOT DEAL_II_WITH_METIS)
   message(FATAL_ERROR "
-Error! OpenIFEM requires a deal.ii libray that was configured with the following options:
+Error! OpenIFEM requires a deal.ii library that was configured with the following options:
     DEAL_II_WITH_METIS = ON
 However, the deal.II library found at ${DEAL_II_PATH} was configured with these options
     DEAL_II_WITH_METIS = ${DEAL_II_WITH_METIS}

--- a/cmake/modules/Findrkpm-rk4.cmake
+++ b/cmake/modules/Findrkpm-rk4.cmake
@@ -1,6 +1,6 @@
 # A very simple script to find rkpm-rk4
 #
-# This moudle exports:
+# This module exports:
 #   rkpm-rk4_FOUND
 #   rkpm-rk4_LIBRARY
 #   rkpm-rk4_INCLUDE_DIR

--- a/cmake/modules/Findshell-element.cmake
+++ b/cmake/modules/Findshell-element.cmake
@@ -1,6 +1,6 @@
 # A very simple script to find shell-element
 #
-# This moudle exports:
+# This module exports:
 #   shell-element_FOUND
 #   shell-element_LIBRARY
 #   shell-element_INCLUDE_DIR

--- a/include/cv_fsi.h
+++ b/include/cv_fsi.h
@@ -73,7 +73,7 @@ namespace MPI
     */
     std::vector<double> control_volume_boundaries;
     /* The outer map stores the inner maps by the sequence of x coordinates.
-       the inner map stores the fluid cells in the control volume by the sequnce
+       the inner map stores the fluid cells in the control volume by the sequence
        of y coordinates.
     */
     std::map<double, std::map<double, cell_iterator>> cv_f_cells;
@@ -89,7 +89,7 @@ namespace MPI
               std::tuple<cell_iterator, cell_iterator, double>>
       bernoulli_start_end;
     /* Streamline path for Bernoulli analysis. The key is the center x
-       coordinate for sorting. Firt iterator is for vector DoF and second is for
+       coordinate for sorting. First iterator is for vector DoF and second is for
        scalar DoF handler. Note: this is local
     */
     std::map<double, std::pair<cell_iterator, cell_iterator>>

--- a/include/hyper_elasticity.h
+++ b/include/hyper_elasticity.h
@@ -169,7 +169,7 @@ namespace Solid
                                     //! first iteration.
     double normalized_error_update; //!< error_update / initial_error_update
 
-    // Reture the residual in the Newton iteration
+    // Return the residual in the Newton iteration
     void get_error_residual(double &);
     // Compute the l2 norm of the solution increment
     void get_error_update(const Vector<double> &, double &);

--- a/include/linear_elastic_material.h
+++ b/include/linear_elastic_material.h
@@ -7,7 +7,7 @@
 
 namespace Solid
 {
-  /*! \breif Linear elastic material.
+  /*! \brief Linear elastic material.
    */
   template <int dim>
   class LinearElasticMaterial : public Material<dim>

--- a/include/mpi_fluid_solver_extractor.h
+++ b/include/mpi_fluid_solver_extractor.h
@@ -43,7 +43,7 @@ namespace Fluid
       static const Parameters::AllParameters *
       get_parameters(const FluidSolver<dim> &);
 
-      /// Retruns the partitions. The first and second items in the returned
+      /// Returns the partitions. The first and second items in the returned
       /// tuple are owned and relevant partitions for velocity-pressure dofs.
       /// The third and fourth items are owned and relevant partitions for
       /// scalar dofs.

--- a/include/mpi_fsi.h
+++ b/include/mpi_fsi.h
@@ -145,7 +145,7 @@ namespace MPI
     // (x_min, x_max, y_min, y_max, z_min, z_max)
     Vector<double> solid_box;
 
-    // This vector collects the solid boundaries for computing thw winding
+    // This vector collects the solid boundaries for computing the winding
     // number.
     std::list<std::pair<typename Triangulation<dim>::active_cell_iterator,
                         unsigned int>>

--- a/include/mpi_hyper_elasticity.h
+++ b/include/mpi_hyper_elasticity.h
@@ -160,7 +160,7 @@ namespace Solid
                                    //! first iteration.
       double normalized_error_update; //!< error_update / initial_error_update
 
-      // Reture the residual in the Newton iteration
+      // Return the residual in the Newton iteration
       void get_error_residual(double &);
       // Compute the l2 norm of the solution increment
       void get_error_update(const PETScWrappers::MPI::Vector &, double &);

--- a/include/mpi_scnsex.h
+++ b/include/mpi_scnsex.h
@@ -22,7 +22,7 @@ namespace Fluid
      *
      * Explicit time scheme is used for time stepping. The velocity and pressure
      * dofs are decoupled and solved separately. A inner iteration is
-     * incoporated to make sure the solution converges. However, the explicit
+     * incorporated to make sure the solution converges. However, the explicit
      * solver has a strict restriction on time step size. For pure acoustic wave
      * propagation, the time step must be smaller than 1e-7s for convergence.
      *
@@ -94,9 +94,9 @@ namespace Fluid
        */
       PETScWrappers::MPI::BlockVector evaluation_point;
 
-      /** \breif local_matrices
+      /** \brief local_matrices
        * The local matrices is stored in each cell such that the program does
-       * not need repeatly assemble the system matrix. Usually, one global
+       * not need repeatedly assemble the system matrix. Usually, one global
        * matrix suffices for such purpose. However, for time-dependent BC, we
        * need to update the inhomogenius constraints which needs the information
        * from the local system matrices.
@@ -106,7 +106,7 @@ namespace Fluid
         FullMatrix<double>>
         local_matrices;
 
-      /** \breif boundary_condition_time_limits
+      /** \brief boundary_condition_time_limits
        * This map stores the time limit for each time dependent hard coded
        * boundary conditions. In the explicit solver, the system matrix does not
        * have to re-assemble at each time step unless a time dependent boundary

--- a/include/mpi_shared_hyper_elasticity.h
+++ b/include/mpi_shared_hyper_elasticity.h
@@ -139,7 +139,7 @@ namespace Solid
                                    //! first iteration.
       double normalized_error_update; //!< error_update / initial_error_update
 
-      // Reture the residual in the Newton iteration
+      // Return the residual in the Newton iteration
       void get_error_residual(double &);
       // Compute the l2 norm of the solution increment
       void get_error_update(const PETScWrappers::MPI::Vector &, double &);

--- a/include/mpi_shared_solid_solver.h
+++ b/include/mpi_shared_solid_solver.h
@@ -186,7 +186,7 @@ namespace Solid
        * every
        * timestep. But displacement and velocity also contribute to the rhs of
        * the equation. For the sake of clarity, we explicitly store two sets of
-       * accleration, velocity and displacement.
+       * acceleration, velocity and displacement.
        */
       PETScWrappers::MPI::Vector current_acceleration;
       PETScWrappers::MPI::Vector current_velocity;

--- a/include/mpi_solid_solver.h
+++ b/include/mpi_solid_solver.h
@@ -127,7 +127,7 @@ namespace Solid
                                       //!< dof per vertex.
       FESystem<dim> fe;
       FE_DGQ<dim>
-        dg_fe; //!< Discontinous Glerkin FE for the nodal strain/stress
+        dg_fe; //!< Discontinuous Glerkin FE for the nodal strain/stress
       const QGauss<dim>
         volume_quad_formula; //!< Quadrature formula for volume integration.
       const QGauss<dim - 1>
@@ -152,7 +152,7 @@ namespace Solid
        * every
        * timestep. But displacement and velocity also contribute to the rhs of
        * the equation. For the sake of clarity, we explicitly store two sets of
-       * accleration, velocity and displacement.
+       * acceleration, velocity and displacement.
        */
       PETScWrappers::MPI::Vector current_acceleration;
       PETScWrappers::MPI::Vector current_velocity;

--- a/include/mpi_spalart_allmaras.h
+++ b/include/mpi_spalart_allmaras.h
@@ -66,7 +66,7 @@ namespace Fluid
 
       virtual double get_shear_velocity(double, double) override;
 
-      //! Desctructor
+      //! Destructor
       ~SpalartAllmaras(){};
 
     protected:

--- a/include/mpi_turbulence_model.h
+++ b/include/mpi_turbulence_model.h
@@ -77,20 +77,20 @@ namespace Fluid
       virtual bool load_checkpoint() = 0;
 
       /// Transfer the solution to the locally refined mesh. pre_refine_mesh
-      /// should be called before adapative refinement.
+      /// should be called before adaptive refinement.
       virtual void pre_refine_mesh(
         std::optional<parallel::distributed::
                         SolutionTransfer<dim, PETScWrappers::MPI::Vector>>
           &) = 0;
 
       /// Transfer the solution to the locally refined mesh. post_refine_mesh
-      /// should be called after adapative refinement.
+      /// should be called after adaptive refinement.
       virtual void post_refine_mesh(
         std::optional<parallel::distributed::
                         SolutionTransfer<dim, PETScWrappers::MPI::Vector>>
           &) = 0;
 
-      //! Desctructor
+      //! Destructor
       virtual ~TurbulenceModel();
 
     protected:

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -91,7 +91,7 @@ namespace Parameters
      * Spalart-Allmaras model BCs are stored as a map between fluid boundary id
      * and an int which indicates what kind of condition is applied:
      * 0: wall (all boundaries with no-penetration fluid bc)
-     * 1: inflow (fluid velocity / pressue inlet)
+     * 1: inflow (fluid velocity / pressure inlet)
      */
     std::map<unsigned int, unsigned int> spalart_allmaras_model_bcs;
     double spalart_allmaras_initial_condition_coefficient;

--- a/include/solid_solver.h
+++ b/include/solid_solver.h
@@ -144,7 +144,7 @@ namespace Solid
      * every
      * timestep. But displacement and velocity also contribute to the rhs of the
      * equation.
-     * For the sake of clarity, we explicitly store two sets of accleration,
+     * For the sake of clarity, we explicitly store two sets of acceleration,
      * velocity
      * and displacement.
      */

--- a/source/cv_fsi.cpp
+++ b/source/cv_fsi.cpp
@@ -1255,7 +1255,7 @@ namespace MPI
     ***********************IMPORTANT*********************
     gap_tolerance is a HARD-CODED value designed for bernoulli analysis in VF
     simulation. When the gap size exceeds this value, the contraction and jet
-    regions are considered separated. Change it if neccessary.
+    regions are considered separated. Change it if necessary.
     **********************************************
     */
     double gap_tolerance = 0.0045;
@@ -1424,7 +1424,7 @@ namespace MPI
         |------|------|------|
           0101   1111   1010
             5     15     10
-        A cell has the corresponding flag if at least one vertex satisifies the
+        A cell has the corresponding flag if at least one vertex satisfies the
         condition. Therefore, the flag "in_conraction" and "not_in_contraction"
         can co-exist and so do "in_jet" and "not_in_jet".
         The flags seem redundant as partial cells are not accounted at all now,

--- a/source/fsi.cpp
+++ b/source/fsi.cpp
@@ -142,7 +142,7 @@ void FSI<dim>::update_solid_displacement()
 
 // Dirichlet bcs are applied to artificial fluid cells, so fluid nodes should
 // be marked as artificial or real. Meanwhile, additional body force is
-// applied to the artificial fluid quadrature points. To accomodate these two
+// applied to the artificial fluid quadrature points. To accommodate these two
 // settings, we define indicator at quadrature points, but only when all
 // of the vertices of a fluid cell are found to be in solid domain,
 // set the indicators at all quadrature points to be 1.

--- a/source/insim.cpp
+++ b/source/insim.cpp
@@ -349,7 +349,7 @@ namespace Fluid
 
     // NOTE: SolverFGMRES only applies the preconditioner from the right,
     // as opposed to SolverGMRES which allows both left and right
-    // preconditoners.
+    // preconditioners.
     SolverControl solver_control(
       system_matrix.m(), std::max(1e-8 * system_rhs.l2_norm(), 1e-10), true);
     GrowingVectorMemory<BlockVector<double>> vector_memory;

--- a/source/linear_elasticity.cpp
+++ b/source/linear_elasticity.cpp
@@ -252,7 +252,7 @@ namespace Solid
 
     if (first_step)
       {
-        // Neet to compute the initial acceleration, \f$ Ma_n = F \f$,
+        // Need to compute the initial acceleration, \f$ Ma_n = F \f$,
         // at this point set system_matrix to mass_matrix.
         assemble_system(true);
         this->solve(system_matrix, previous_acceleration, system_rhs);

--- a/source/mpi_fsi.cpp
+++ b/source/mpi_fsi.cpp
@@ -118,7 +118,7 @@ namespace MPI
   template <int dim>
   void FSI<dim>::update_vertices_mask()
   {
-    // Initilize vertices mask
+    // Initialize vertices mask
     vertices_mask.clear();
     vertices_mask.resize(fluid_solver.triangulation.n_vertices(), false);
     for (auto cell = fluid_solver.triangulation.begin_active();
@@ -281,7 +281,7 @@ namespace MPI
 
   // Dirichlet bcs are applied to artificial fluid cells, so fluid nodes
   // should be marked as artificial or real. Meanwhile, additional body force
-  // is acted at the artificial fluid quadrature points. To accomodate these
+  // is acted at the artificial fluid quadrature points. To accommodate these
   // two settings, we define indicator at quadrature points, but only when all
   // of the vertices of a fluid cell are found to be in solid domain,
   // set the indicators at all quadrature points to be 1.

--- a/source/mpi_linear_elasticity.cpp
+++ b/source/mpi_linear_elasticity.cpp
@@ -206,7 +206,7 @@ namespace Solid
 
       if (first_step)
         {
-          // Neet to compute the initial acceleration, \f$ Ma_n = F \f$,
+          // Need to compute the initial acceleration, \f$ Ma_n = F \f$,
           // at this point set system_matrix to mass_matrix.
           assemble_system(true);
           this->solve(system_matrix, previous_acceleration, system_rhs);

--- a/source/mpi_spalart_allmaras.cpp
+++ b/source/mpi_spalart_allmaras.cpp
@@ -151,7 +151,7 @@ namespace Fluid
       const std::vector<Point<dim>> &unit_points =
         scalar_fe->get_unit_support_points();
 
-      // von Karman constan for wall function
+      // von Karman constant for wall function
       constexpr double kappa{0.41};
       for (const auto &cell : scalar_dof_handler->active_cell_iterators())
         {
@@ -249,7 +249,7 @@ namespace Fluid
                c3 * std::atan2(b1, yp + a1) - c4 * std::atan2(b2, yp + a2);
       };
 
-      // Derivative of u+ in repect to y+
+      // Derivative of u+ in respect to y+
       constexpr double kappa{0.41}, c_nu1_cubed{7.1 * 7.1 * 7.1},
         kappa_cubed{kappa * kappa * kappa};
       auto dup_dyp = [ kappa_cubed, c_nu1_cubed ](double yp) constexpr

--- a/source/parameters.cpp
+++ b/source/parameters.cpp
@@ -466,7 +466,7 @@ namespace Parameters
       prm.declare_entry("Damping",
                         "0.0",
                         Patterns::Double(0.0),
-                        "The artifical damping in Newmark-beta method");
+                        "The artificial damping in Newmark-beta method");
       prm.declare_entry("Max Newton iterations",
                         "8",
                         Patterns::Integer(1),

--- a/source/parameters.prm
+++ b/source/parameters.prm
@@ -1,5 +1,5 @@
 # This is the input file for the program. There are three blocks of input parameters,
-# namely the simulation block, which contorls the simulation parameters shared by
+# namely the simulation block, which controls the simulation parameters shared by
 # both fluid and solid, such as the simulation time, output frequency and so on.
 # The fluid block controls the behavior of the fluid solver, and the solid solver
 # controls the solid solver.
@@ -90,7 +90,7 @@ subsection Fluid Dirichlet BCs
 end
 
 subsection Fluid Neumann BCs
-  # Number of boundaries with Neumann BCs (specificaly, pressure BC)
+  # Number of boundaries with Neumann BCs (specifically, pressure BC)
   # Note: do-nothing (zero pressure) boundary do not need to be explicitly specified!)
   set Number of Neumann BCs = 0
 

--- a/source/scnsim.cpp
+++ b/source/scnsim.cpp
@@ -527,7 +527,7 @@ namespace Fluid
 
     // NOTE: SolverFGMRES only applies the preconditioner from the right,
     // as opposed to SolverGMRES which allows both left and right
-    // preconditoners.
+    // preconditioners.
     SolverControl solver_control(
       system_matrix.m(), 1e-8 * system_rhs.l2_norm(), true);
     GrowingVectorMemory<BlockVector<double>> vector_memory;


### PR DESCRIPTION
Found via `codespell -q 3`