### PR TITLE
fix errors in buildings

### DIFF
--- a/source/mpi_fsi.cpp
+++ b/source/mpi_fsi.cpp
@@ -2,6 +2,9 @@
 #include "mpi_spalart_allmaras.h"
 #include <iostream>
 
+// for building in some systems
+#include <optional>
+
 namespace MPI
 {
   template <int dim>


### PR DESCRIPTION
explicitly include the standard optional library for building in some systems that fails to support c++17 standard automatically.